### PR TITLE
fix: Change host for route

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Service Catalog
 
-This is the service catalog for the [operate-first](https://github.com/operate-first) community cloud. The catalog can be accessed with [this](http://example.org) link or via the operate first [website](https://www.operate-first.cloud).
+This is the service catalog for the [operate-first](https://github.com/operate-first) community cloud. The catalog can be accessed with [this](https://service-catalog.operate-first.cloud) link or via the operate first [website](https://www.operate-first.cloud).
 
 ## Architecture
 

--- a/app-config.prod.yaml
+++ b/app-config.prod.yaml
@@ -1,7 +1,7 @@
 # Used in production setup on a k8s/openshift cluster
 
 backend:
-  baseUrl: https://service-catalog-service-catalog.apps.smaug.na.operate-first.cloud
+  baseUrl: https://service-catalog.operate-first.cloud
   database:
     client: pg
     connection:

--- a/manifests/overlays/prod/kustomization.yaml
+++ b/manifests/overlays/prod/kustomization.yaml
@@ -16,11 +16,5 @@ patches:
     target:
       kind: Deployment
       name: service-catalog
-  - patch: |
-      - op: add
-        path: /metadata/annotations
-        value:
-          kubernetes.io/tls-acme: "true"
-    target:
-      kind: Route
-      name: service-catalog
+patchesStrategicMerge:
+  - route.yaml

--- a/manifests/overlays/prod/route.yaml
+++ b/manifests/overlays/prod/route.yaml
@@ -1,0 +1,8 @@
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  name: service-catalog
+  annotations:
+    kubernetes.io/tls-acme: "true"
+spec:
+  host: service-catalog.operate-first.cloud


### PR DESCRIPTION
The default route host name was too long for `tls-acme` so a certificate couldn't be created.
The new `DNS CNAME` record (service-catalog.operate-first.cloud) was already added.