### PR TITLE
feat: Add home page with catalog overview

### DIFF
--- a/examples/components/service1.yaml
+++ b/examples/components/service1.yaml
@@ -7,6 +7,8 @@ metadata:
     - url: https://example.org
       title: Support path
       icon: user
+  annotations:
+    operate-first.cloud/component-icon-url: https://picsum.photos/200
 spec:
   type: service
   lifecycle: production

--- a/examples/components/service2.yaml
+++ b/examples/components/service2.yaml
@@ -7,6 +7,8 @@ metadata:
     - url: https://example.org
       title: Support path
       icon: user
+  annotations:
+    operate-first.cloud/component-icon-url: https://picsum.photos/201
 spec:
   type: service
   lifecycle: production

--- a/examples/components/service3.yaml
+++ b/examples/components/service3.yaml
@@ -7,6 +7,8 @@ metadata:
     - url: https://example.org
       title: Support path
       icon: user
+  annotations:
+    operate-first.cloud/component-icon-url: https://picsum.photos/202
 spec:
   type: service
   lifecycle: production

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -21,6 +21,7 @@
     "@backstage/plugin-catalog-import": "^0.8.8",
     "@backstage/plugin-catalog-react": "^1.1.0",
     "@backstage/plugin-github-actions": "^0.5.5",
+    "@backstage/plugin-home": "^0.4.22",
     "@backstage/plugin-org": "^0.5.5",
     "@backstage/plugin-permission-react": "^0.4.1",
     "@backstage/plugin-scaffolder": "^1.2.0",

--- a/packages/app/src/App.tsx
+++ b/packages/app/src/App.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Navigate, Route } from 'react-router';
+import { Route } from 'react-router';
 import { apiDocsPlugin, ApiExplorerPage } from '@backstage/plugin-api-docs';
 import {
   CatalogEntityPage,
@@ -32,6 +32,8 @@ import { FlatRoutes } from '@backstage/core-app-api';
 import { CatalogGraphPage } from '@backstage/plugin-catalog-graph';
 import { PermissionedRoute } from '@backstage/plugin-permission-react';
 import { catalogEntityCreatePermission } from '@backstage/plugin-catalog-common/alpha';
+import { HomepageCompositionRoot } from '@backstage/plugin-home';
+import { HomePage } from './components/home/HomePage';
 
 const app = createApp({
   apis,
@@ -57,7 +59,9 @@ const AppRouter = app.getRouter();
 
 const routes = (
   <FlatRoutes>
-    <Navigate key="/" to="catalog" />
+    <Route path="/" element={<HomepageCompositionRoot />}>
+      <HomePage />
+    </Route>
     <Route path="/catalog" element={<CatalogIndexPage />} />
     <Route
       path="/catalog/:namespace/:kind/:name"

--- a/packages/app/src/components/Root/Root.tsx
+++ b/packages/app/src/components/Root/Root.tsx
@@ -16,10 +16,10 @@
 
 import React, { useContext, PropsWithChildren } from 'react';
 import { Link, makeStyles } from '@material-ui/core';
-// import HomeIcon from '@material-ui/icons/Home';
+import HomeIcon from '@material-ui/icons/Home';
 // import ExtensionIcon from '@material-ui/icons/Extension';
 // import MapIcon from '@material-ui/icons/MyLocation';
-import LibraryBooks from '@material-ui/icons/LibraryBooks';
+import CategoryIcon from '@material-ui/icons/Category';
 // import CreateComponentIcon from '@material-ui/icons/AddCircleOutline';
 import LogoFull from './LogoFull';
 import LogoIcon from './LogoIcon';
@@ -86,7 +86,8 @@ export const Root = ({ children }: PropsWithChildren<{}>) => (
       <SidebarDivider />
       <SidebarGroup label="Menu" icon={<MenuIcon />}>
         {/* Global nav, not org-specific */}
-        <SidebarItem icon={LibraryBooks} to="catalog" text="Service Catalog" />
+        <SidebarItem icon={HomeIcon} to="/" text="Home" />
+        <SidebarItem icon={CategoryIcon} to="catalog" text="Catalog" />
         {/* <SidebarItem icon={ExtensionIcon} to="api-docs" text="APIs" /> */}
         {/* <SidebarItem icon={LibraryBooks} to="docs" text="Docs" /> */}
         {/* <SidebarItem icon={CreateComponentIcon} to="create" text="Create..." /> */}

--- a/packages/app/src/components/home/HomePage.tsx
+++ b/packages/app/src/components/home/HomePage.tsx
@@ -1,0 +1,163 @@
+import React, { useState } from 'react';
+import { SearchContextProvider } from '@backstage/plugin-search-react';
+import {
+  Content,
+  Page,
+  InfoCard,
+  WarningPanel,
+  CodeSnippet,
+  HelpIcon,
+} from '@backstage/core-components';
+import {
+  HomePageCompanyLogo,
+  TemplateBackstageLogo,
+} from '@backstage/plugin-home';
+import { HomePageSearchBar } from '@backstage/plugin-search';
+import {
+  CircularProgress,
+  Grid,
+  makeStyles,
+  Typography,
+} from '@material-ui/core';
+
+import { catalogApiRef, EntityRefLink } from '@backstage/plugin-catalog-react';
+import useAsyncFn from 'react-use/lib/useAsyncFn';
+import useDebounce from 'react-use/lib/useDebounce';
+import { useApi } from '@backstage/core-plugin-api';
+import { Entity } from '@backstage/catalog-model';
+
+const useStyles = makeStyles(theme => ({
+  searchBar: {
+    display: 'flex',
+    maxWidth: '60vw',
+    backgroundColor: theme.palette.background.paper,
+    boxShadow: theme.shadows[1],
+    padding: '8px 0',
+    borderRadius: '50px',
+    margin: 'auto',
+  },
+}));
+
+const useLogoStyles = makeStyles(theme => ({
+  container: {
+    margin: theme.spacing(5, 0),
+  },
+  svg: {
+    width: 'auto',
+    height: 100,
+  },
+  path: {
+    fill: '#7df3e1',
+  },
+}));
+
+const useCatalogStyles = makeStyles({
+  root: {
+    transition: 'all .25s linear',
+    textAlign: 'center',
+    '&:hover': {
+      boxShadow: '0px 0px 16px 0px rgba(0,0,0,0.8)',
+    },
+    '& svg': {
+      fontSize: 80,
+    },
+    '& img': {
+      height: 80,
+      width: 80,
+    },
+  },
+  subheader: {
+    display: 'block',
+    width: '100%',
+  },
+  link: {
+    '&:hover': {
+      textDecoration: 'none',
+    },
+  },
+});
+const ICON_ANNOTATION = 'operate-first.cloud/component-icon-url';
+
+const CatalogCards = () => {
+  const catalogApi = useApi(catalogApiRef);
+  const classes = useCatalogStyles();
+  const [entities, setEntities] = useState<Entity[]>([]);
+  const [{ loading, error }, refresh] = useAsyncFn(
+    async () => {
+      const response = await catalogApi.getEntities();
+      setEntities(response.items.filter(e => e.kind === 'Component'));
+    },
+    [catalogApi],
+    { loading: true },
+  );
+  useDebounce(refresh, 10);
+
+  if (error) {
+    return (
+      <WarningPanel severity="error" title="Could not fetch catalog entities.">
+        <CodeSnippet language="text" text={error.toString()} />
+      </WarningPanel>
+    );
+  }
+
+  if (loading) {
+    return <CircularProgress />;
+  }
+
+  return (
+    <>
+      {entities.map(e => (
+        <Grid item xs={12} sm={6} md={4} lg={3} xl={2} key={e.metadata.name}>
+          <EntityRefLink entityRef={e} className={classes.link}>
+            <InfoCard
+              className={classes.root}
+              title={
+                e.metadata.annotations?.[ICON_ANNOTATION] ? (
+                  <img
+                    src={e.metadata.annotations[ICON_ANNOTATION]}
+                    alt={`${e.metadata.name} logo`}
+                  />
+                ) : (
+                  <HelpIcon />
+                )
+              }
+              subheader={
+                <div className={classes.subheader}>{e.metadata.name}</div>
+              }
+            >
+              <Typography paragraph>{e.metadata.description}</Typography>
+            </InfoCard>
+          </EntityRefLink>
+        </Grid>
+      ))}
+    </>
+  );
+};
+export const HomePage = () => {
+  const classes = useStyles();
+  const { svg, path, container } = useLogoStyles();
+
+  return (
+    <SearchContextProvider>
+      <Page themeId="home">
+        <Content>
+          <Grid container justifyContent="center" spacing={6}>
+            <HomePageCompanyLogo
+              className={container}
+              logo={<TemplateBackstageLogo classes={{ svg, path }} />}
+            />
+            <Grid container item xs={12} alignItems="center" direction="row">
+              <HomePageSearchBar
+                classes={{ root: classes.searchBar }}
+                placeholder="Search"
+              />
+            </Grid>
+            <Grid container item xs={12} justifyContent="center">
+              <CatalogCards />
+            </Grid>
+          </Grid>
+        </Content>
+      </Page>
+    </SearchContextProvider>
+  );
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -1336,10 +1336,32 @@
     "@backstage/errors" "^1.0.0"
     cross-fetch "^3.1.5"
 
+"@backstage/catalog-client@^1.0.3":
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/@backstage/catalog-client/-/catalog-client-1.0.3.tgz#cb91472ccc31df322f69e7e4e80939b3535660cd"
+  integrity sha512-35Es9jFB9jOZTEtEeCyZHES0bcQkfX4qbmY1GuC6e6ZtO120w+595kmKxc744d7X2WXUIWvhRubqc9/w5blKbg==
+  dependencies:
+    "@backstage/catalog-model" "^1.0.3"
+    "@backstage/errors" "^1.0.0"
+    cross-fetch "^3.1.5"
+
 "@backstage/catalog-model@^1.0.2":
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/@backstage/catalog-model/-/catalog-model-1.0.2.tgz#50328068632b452fabed67e53fb7f83ead08f9df"
   integrity sha512-0GCTW0XqFoHRiZKRXiru5wVMm0hoPiFAEyBiudWlYAFXtVEoVnrzJ+pa9F96zqtFgcGHmgSybgzjmVqiGUMSlw==
+  dependencies:
+    "@backstage/config" "^1.0.1"
+    "@backstage/errors" "^1.0.0"
+    "@backstage/types" "^1.0.0"
+    ajv "^8.10.0"
+    json-schema "^0.4.0"
+    lodash "^4.17.21"
+    uuid "^8.0.0"
+
+"@backstage/catalog-model@^1.0.3":
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/@backstage/catalog-model/-/catalog-model-1.0.3.tgz#0d7bd832add56650871b95894878540fc41a4ef9"
+  integrity sha512-rbXdA/CI8EzpsthlSI4JonLd4RZoki7IN6tFvivjKDMlW8IVb63BJXWO4VnvHH+LLYzH4/OaL051YeoaicdqYw==
   dependencies:
     "@backstage/config" "^1.0.1"
     "@backstage/errors" "^1.0.0"
@@ -1541,10 +1563,68 @@
     zen-observable "^0.8.15"
     zod "^3.11.6"
 
+"@backstage/core-components@^0.9.5":
+  version "0.9.5"
+  resolved "https://registry.yarnpkg.com/@backstage/core-components/-/core-components-0.9.5.tgz#5a0b34867aaee0549bfa67b39a69c09588fa3c7a"
+  integrity sha512-kfAdN70idiEqHeH9ZQryn6C0RxJEKiRc/7srYIz0CVV88zJfc0nmZ5C/S10Gkht2xWfm95tTSw2P1vEYIBbfxg==
+  dependencies:
+    "@backstage/config" "^1.0.1"
+    "@backstage/core-plugin-api" "^1.0.3"
+    "@backstage/errors" "^1.0.0"
+    "@backstage/theme" "^0.2.15"
+    "@backstage/version-bridge" "^1.0.1"
+    "@material-table/core" "^3.1.0"
+    "@material-ui/core" "^4.12.2"
+    "@material-ui/icons" "^4.9.1"
+    "@material-ui/lab" "4.0.0-alpha.57"
+    "@react-hookz/web" "^14.0.0"
+    "@types/react-sparklines" "^1.7.0"
+    "@types/react-text-truncate" "^0.14.0"
+    ansi-regex "^6.0.1"
+    classnames "^2.2.6"
+    d3-selection "^3.0.0"
+    d3-shape "^3.0.0"
+    d3-zoom "^3.0.0"
+    dagre "^0.8.5"
+    history "^5.0.0"
+    immer "^9.0.1"
+    lodash "^4.17.21"
+    pluralize "^8.0.0"
+    prop-types "^15.7.2"
+    qs "^6.9.4"
+    rc-progress "3.3.3"
+    react-helmet "6.1.0"
+    react-hook-form "^7.12.2"
+    react-markdown "^8.0.0"
+    react-router "6.0.0-beta.0"
+    react-router-dom "6.0.0-beta.0"
+    react-sparklines "^1.7.0"
+    react-syntax-highlighter "^15.4.5"
+    react-text-truncate "^0.19.0"
+    react-use "^17.3.2"
+    react-virtualized-auto-sizer "^1.0.6"
+    react-window "^1.8.6"
+    remark-gfm "^3.0.1"
+    zen-observable "^0.8.15"
+    zod "^3.11.6"
+
 "@backstage/core-plugin-api@^1.0.2":
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/@backstage/core-plugin-api/-/core-plugin-api-1.0.2.tgz#6ebf52c20df33ee3c128c98937d0d349a805d3eb"
   integrity sha512-82bFp3lTW4o4Bske+zLXSzHueLP/mdUPWx6J/6YUfn88Aq93gb4VrdUJ04fXXDNWPqaBzfpynaIbme9QRZqfHQ==
+  dependencies:
+    "@backstage/config" "^1.0.1"
+    "@backstage/types" "^1.0.0"
+    "@backstage/version-bridge" "^1.0.1"
+    history "^5.0.0"
+    prop-types "^15.7.2"
+    react-router-dom "6.0.0-beta.0"
+    zen-observable "^0.8.15"
+
+"@backstage/core-plugin-api@^1.0.3":
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/@backstage/core-plugin-api/-/core-plugin-api-1.0.3.tgz#32ecfec2afe1a25d02d41f1813621843121c2d7a"
+  integrity sha512-4/d9+c+AmqhY5KqsC8ikIcMsmXIcKP3+1/uT2H3/DxxJLx2sH7BvNVVqro5ZAhA7iNsuYdrfV0fHeNxGsdLuNA==
   dependencies:
     "@backstage/config" "^1.0.1"
     "@backstage/types" "^1.0.0"
@@ -1582,6 +1662,20 @@
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/@backstage/integration/-/integration-1.2.0.tgz#89a3fc95c079c541ca6a5cafc613ebefc0463687"
   integrity sha512-ZUfaMUUEUlmS2JE4M0Z4fXe269Z+hRGooptgILC21hgXW20hjVrhb7Q6ynH78md0ItcEuHVs2mnCztc7LS8erg==
+  dependencies:
+    "@backstage/config" "^1.0.1"
+    "@backstage/errors" "^1.0.0"
+    "@octokit/auth-app" "^3.4.0"
+    "@octokit/rest" "^18.5.3"
+    cross-fetch "^3.1.5"
+    git-url-parse "^11.6.0"
+    lodash "^4.17.21"
+    luxon "^2.0.2"
+
+"@backstage/integration@^1.2.1":
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/@backstage/integration/-/integration-1.2.1.tgz#a1931d240c2fbd304f0b87d54272709f4ffe83ed"
+  integrity sha512-9rXD1iIGhKRCfowxWx9sRKxiv1JvDI6ucvtUeXIj1G27kT/Xy7uUcgB8CkVxsvSeog5Z1VdYkFkDmQbKQ6GPrg==
   dependencies:
     "@backstage/config" "^1.0.1"
     "@backstage/errors" "^1.0.0"
@@ -1742,6 +1836,14 @@
     "@backstage/plugin-permission-common" "^0.6.1"
     "@backstage/search-common" "^0.3.4"
 
+"@backstage/plugin-catalog-common@^1.0.3":
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/@backstage/plugin-catalog-common/-/plugin-catalog-common-1.0.3.tgz#96b1de2847fec0533c49ee19f93781777eedfd0d"
+  integrity sha512-Sf5IQocTRQaTh9ofZUy4/szWwDl5Eek6odKVx6v33jrMot5i3grybOELrVM3/Kgcr+5/ixSSopgQPUFO/T9KBA==
+  dependencies:
+    "@backstage/plugin-permission-common" "^0.6.2"
+    "@backstage/plugin-search-common" "^0.3.5"
+
 "@backstage/plugin-catalog-graph@^0.2.17":
   version "0.2.17"
   resolved "https://registry.yarnpkg.com/@backstage/plugin-catalog-graph/-/plugin-catalog-graph-0.2.17.tgz#b45deddbfc3a359037711b76016ffb16e87eacfa"
@@ -1818,6 +1920,35 @@
     yaml "^1.10.0"
     zen-observable "^0.8.15"
 
+"@backstage/plugin-catalog-react@^1.1.1":
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/@backstage/plugin-catalog-react/-/plugin-catalog-react-1.1.1.tgz#0441bcf1291349ad355ff51e28245d7ea26a3e01"
+  integrity sha512-HxowTsFaNmAp+TEb0YgBak/61SkwwRV3tUdF5O2dQugbgI3Ci8dMjN2J18LiOEFS13m6IlrCpNC1Db3QMRjwBA==
+  dependencies:
+    "@backstage/catalog-client" "^1.0.3"
+    "@backstage/catalog-model" "^1.0.3"
+    "@backstage/core-components" "^0.9.5"
+    "@backstage/core-plugin-api" "^1.0.3"
+    "@backstage/errors" "^1.0.0"
+    "@backstage/integration" "^1.2.1"
+    "@backstage/plugin-catalog-common" "^1.0.3"
+    "@backstage/plugin-permission-common" "^0.6.2"
+    "@backstage/plugin-permission-react" "^0.4.2"
+    "@backstage/theme" "^0.2.15"
+    "@backstage/types" "^1.0.0"
+    "@backstage/version-bridge" "^1.0.1"
+    "@material-ui/core" "^4.12.2"
+    "@material-ui/icons" "^4.9.1"
+    "@material-ui/lab" "4.0.0-alpha.57"
+    classnames "^2.2.6"
+    jwt-decode "^3.1.0"
+    lodash "^4.17.21"
+    qs "^6.9.4"
+    react-router "6.0.0-beta.0"
+    react-use "^17.2.4"
+    yaml "^1.10.0"
+    zen-observable "^0.8.15"
+
 "@backstage/plugin-catalog@^1.2.0":
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/@backstage/plugin-catalog/-/plugin-catalog-1.2.0.tgz#1b6e5da376e6e5df0b8f3ea6d213cff5a2381ec9"
@@ -1863,6 +1994,25 @@
     luxon "^2.0.2"
     react-router "6.0.0-beta.0"
     react-router-dom "6.0.0-beta.0"
+    react-use "^17.2.4"
+
+"@backstage/plugin-home@^0.4.22":
+  version "0.4.22"
+  resolved "https://registry.yarnpkg.com/@backstage/plugin-home/-/plugin-home-0.4.22.tgz#efc54ebffb83a2a36dcd43e65142c30be5d8559d"
+  integrity sha512-0LPCyz1/nJraVdq+vkpS8g+8rnVTqY9oz5a+tOEnA6Beldlnd1xGa/qYfaH7s/5jFjd+XQRYoNw7qvioHLC16Q==
+  dependencies:
+    "@backstage/catalog-model" "^1.0.3"
+    "@backstage/config" "^1.0.1"
+    "@backstage/core-components" "^0.9.5"
+    "@backstage/core-plugin-api" "^1.0.3"
+    "@backstage/plugin-catalog-react" "^1.1.1"
+    "@backstage/plugin-stack-overflow" "^0.1.2"
+    "@backstage/theme" "^0.2.15"
+    "@material-ui/core" "^4.12.2"
+    "@material-ui/icons" "^4.9.1"
+    "@material-ui/lab" "4.0.0-alpha.57"
+    lodash "^4.17.21"
+    react-router "6.0.0-beta.0"
     react-use "^17.2.4"
 
 "@backstage/plugin-org@^0.5.5":
@@ -1917,6 +2067,17 @@
     uuid "^8.0.0"
     zod "^3.11.6"
 
+"@backstage/plugin-permission-common@^0.6.2":
+  version "0.6.2"
+  resolved "https://registry.yarnpkg.com/@backstage/plugin-permission-common/-/plugin-permission-common-0.6.2.tgz#2ab5cf3d8a4a3394edc0d552719df4f34804bfbb"
+  integrity sha512-tbKjm0xw6stoaFzeWL59XRz/yEEXxnBMgm3ioNbh0Qdbj44z8KivjkDjWPovI5DW6x0jFxzLQYCNMlZxOpqL6A==
+  dependencies:
+    "@backstage/config" "^1.0.1"
+    "@backstage/errors" "^1.0.0"
+    cross-fetch "^3.1.5"
+    uuid "^8.0.0"
+    zod "^3.11.6"
+
 "@backstage/plugin-permission-node@^0.6.1":
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/@backstage/plugin-permission-node/-/plugin-permission-node-0.6.1.tgz#dbdc87eff8fd51eda0381ed5582a2caa46f4d86d"
@@ -1940,6 +2101,19 @@
     "@backstage/config" "^1.0.1"
     "@backstage/core-plugin-api" "^1.0.2"
     "@backstage/plugin-permission-common" "^0.6.1"
+    cross-fetch "^3.1.5"
+    react-router "6.0.0-beta.0"
+    react-use "^17.2.4"
+    swr "^1.1.2"
+
+"@backstage/plugin-permission-react@^0.4.2":
+  version "0.4.2"
+  resolved "https://registry.yarnpkg.com/@backstage/plugin-permission-react/-/plugin-permission-react-0.4.2.tgz#efc39619617e5800a68728871b87c772a0861711"
+  integrity sha512-isofTbK1gFgLTgr51efbFO0jWOkhQwzErL24pwY6gFVKnz7Z53AfGv1lHabxAWnNhEyTzLPMA/7s7lKuKEtOXw==
+  dependencies:
+    "@backstage/config" "^1.0.1"
+    "@backstage/core-plugin-api" "^1.0.3"
+    "@backstage/plugin-permission-common" "^0.6.2"
     cross-fetch "^3.1.5"
     react-router "6.0.0-beta.0"
     react-use "^17.2.4"
@@ -2117,6 +2291,14 @@
     "@backstage/plugin-permission-common" "^0.6.1"
     "@backstage/types" "^1.0.0"
 
+"@backstage/plugin-search-common@^0.3.5":
+  version "0.3.5"
+  resolved "https://registry.yarnpkg.com/@backstage/plugin-search-common/-/plugin-search-common-0.3.5.tgz#6a374541f2bd7d9545e29abbaecc70e7ad1b5ea3"
+  integrity sha512-sq7IDjCLrgZQHBFi+lFVkna3lLRA5eldiTbit/rCUCO4Eq52lWdQHLrQAhsyuObmIWHDh6R2lp2qoL6aAC2AOg==
+  dependencies:
+    "@backstage/plugin-permission-common" "^0.6.2"
+    "@backstage/types" "^1.0.0"
+
 "@backstage/plugin-search-react@^0.2.0":
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/@backstage/plugin-search-react/-/plugin-search-react-0.2.0.tgz#dd9c13c387c666981a902154c2e13850bbbf0d40"
@@ -2151,6 +2333,25 @@
     qs "^6.9.4"
     react-router "6.0.0-beta.0"
     react-router-dom "6.0.0-beta.0"
+    react-use "^17.2.4"
+
+"@backstage/plugin-stack-overflow@^0.1.2":
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/@backstage/plugin-stack-overflow/-/plugin-stack-overflow-0.1.2.tgz#bc140bb22d239a7106f91ea1d4c637551dc91ca5"
+  integrity sha512-6phLbR7E/iZjuNFFStsO2zcJYDijPTS8WEyxhM/rX1Q/OeliMgGBs8V4j1hfHgcjjLz4PPI+EDz/+eeDMi1c4w==
+  dependencies:
+    "@backstage/config" "^1.0.1"
+    "@backstage/core-components" "^0.9.5"
+    "@backstage/core-plugin-api" "^1.0.3"
+    "@backstage/plugin-home" "^0.4.22"
+    "@backstage/plugin-search-common" "^0.3.5"
+    "@backstage/theme" "^0.2.15"
+    "@material-ui/core" "^4.12.2"
+    "@material-ui/icons" "^4.9.1"
+    "@testing-library/jest-dom" "^5.10.1"
+    cross-fetch "^3.1.5"
+    lodash "^4.17.21"
+    qs "^6.9.4"
     react-use "^17.2.4"
 
 "@backstage/plugin-techdocs-backend@^1.1.1":
@@ -4233,7 +4434,7 @@
   resolved "https://registry.yarnpkg.com/@protobufjs/utf8/-/utf8-1.1.0.tgz#a777360b5b39a1a2e5106f8e858f2fd2d060c570"
   integrity sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==
 
-"@react-hookz/deep-equal@^1.0.1":
+"@react-hookz/deep-equal@^1.0.1", "@react-hookz/deep-equal@^1.0.2":
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/@react-hookz/deep-equal/-/deep-equal-1.0.2.tgz#4e8bdeda027379dcf8b62a42e5f75f0351b11b35"
   integrity sha512-cM5kPFb6EFH5q52WzRxfRX9+8g5kq78McWOYs6e1seo+nK6NpfLupT5uOCIJp37jU8ayd4Su8ni3HRFTN2C2kg==
@@ -4244,6 +4445,13 @@
   integrity sha512-KswgkmqBVVDo6UnBFfssrojmDisogxC4jGZmd976R8YHoS3zdQJxjqICpOBSRohbRyYhYS9Cprw7BuV/CZcMaw==
   dependencies:
     "@react-hookz/deep-equal" "^1.0.1"
+
+"@react-hookz/web@^14.0.0":
+  version "14.3.0"
+  resolved "https://registry.yarnpkg.com/@react-hookz/web/-/web-14.3.0.tgz#ccfcfa65aa1e56ca5a3b258a9bd987e0daa67bae"
+  integrity sha512-lmZ9rAoHbBFZo0v72cjHMCY/hz9Wp6WQd/Kx53A+HumxkAaJT3AuBkd9jJgrtdsNiHdG0IEr93/oOza3+G6kVA==
+  dependencies:
+    "@react-hookz/deep-equal" "^1.0.2"
 
 "@rjsf/core@^3.2.1":
   version "3.2.1"
@@ -5030,7 +5238,7 @@
   resolved "https://registry.yarnpkg.com/@types/range-parser/-/range-parser-1.2.4.tgz#cd667bcfdd025213aafb7ca5915a932590acdcdc"
   integrity sha512-EEhsLsD6UsDM1yFhAvy0Cjr6VwmpMWqFBCb9w07wVugF7w9nfajxLuVmngTIpgS6svCnm6Vaw+MZhoDCKnOfsw==
 
-"@types/react-dom@*", "@types/react-dom@<18.0.0", "@types/react-dom@^17":
+"@types/react-dom@*", "@types/react-dom@<18.0.0":
   version "17.0.17"
   resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-17.0.17.tgz#2e3743277a793a96a99f1bf87614598289da68a1"
   integrity sha512-VjnqEmqGnasQKV0CWLevqMTXBYG9GbwuE6x3VetERLh0cq2LTptFE73MrQi2S7GkKXCf2GgwItB/melLnxfnsg==
@@ -15389,6 +15597,15 @@ rc-progress@3.3.2:
     classnames "^2.2.6"
     rc-util "^5.16.1"
 
+rc-progress@3.3.3:
+  version "3.3.3"
+  resolved "https://registry.yarnpkg.com/rc-progress/-/rc-progress-3.3.3.tgz#eb9bffbacab1534f2542f9f6861ce772254362b1"
+  integrity sha512-MDVNVHzGanYtRy2KKraEaWeZLri2ZHWIRyaE1a9MQ2MuJ09m+Wxj5cfcaoaR6z5iRpHpA59YeUxAlpML8N4PJw==
+  dependencies:
+    "@babel/runtime" "^7.10.1"
+    classnames "^2.2.6"
+    rc-util "^5.16.1"
+
 rc-util@^5.16.1:
   version "5.21.5"
   resolved "https://registry.yarnpkg.com/rc-util/-/rc-util-5.21.5.tgz#6e2a5699f820ba915f43f11a4b7dfb0b0672d0fa"
@@ -15636,6 +15853,13 @@ react-text-truncate@^0.18.0:
   version "0.18.0"
   resolved "https://registry.yarnpkg.com/react-text-truncate/-/react-text-truncate-0.18.0.tgz#c65f4be660d24734badb903a4832467eddcf8058"
   integrity sha512-0cc07CRPRPm3cTloVbPicVTSosJNauwVcmJb5FPa71u4KtDVgrRPJoxVvLBubl3gLyx1pVUozgREYMHpHM16jg==
+  dependencies:
+    prop-types "^15.5.7"
+
+react-text-truncate@^0.19.0:
+  version "0.19.0"
+  resolved "https://registry.yarnpkg.com/react-text-truncate/-/react-text-truncate-0.19.0.tgz#60bc5ecf29a03ebc256f31f90a2d8402176aac91"
+  integrity sha512-QxHpZABfGG0Z3WEYbRTZ+rXdZn50Zvp+sWZXgVAd7FCKAMzv/kcwctTpNmWgXDTpAoHhMjOVwmgRtX3x5yeF4w==
   dependencies:
     prop-types "^15.5.7"
 


### PR DESCRIPTION
Resolves: #23 

![image](https://user-images.githubusercontent.com/7453394/176194536-3e865c11-bf82-4eae-8988-452d5758fb38.png)


This adds a homepage with logo, search and list of components as tiles - each is clickable and leads to component detail (same as clicking component name in the Catalog table)