### PR TITLE
chore: Tidy up manifests and readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,15 +29,18 @@ There are 4 configuration files present in this repository. Backstage handles co
 Only edit the base file if you are sure that the change will be relevant for all other 3 configuration files. More information can be found in the backstage [documentation](https://backstage.io/docs/conf/).
 
 ## Backstage version
+
 The external `@backstage` packages can be bumped using
+
 ```sh
 yarn backstage-cli versions:bump
 ```
+
 The current backstage version can be found in `backstage.json`. More about keeping `backstage` up to date can be found [here](https://backstage.io/docs/getting-started/keeping-backstage-updated).
 
-# Contributing
+## Contributing
 
-## Submitting a pull request
+### Submitting a pull request
 
 1. Fork and clone the repository
 2. Make your changes
@@ -52,58 +55,62 @@ Here are a few things you can do that will increase the likelihood of your pull 
 
 Work in Progress pull requests are also welcome to get feedback early on, or if there is something blocked you. Please open such pull requests as *Draft*.
 
-# Development setup
+## Development setup
 
 You can either run a development setup locally or in a k8s cluster.
 
-## Run locally
+### Run locally
 
 Before you begin please install and use supported Node.js version (we support [NVM](https://github.com/nvm-sh/nvm)), check `.nvmrc` for the appropriate version.
 
 Configurations for the local setup are located in `app-config.local.yaml`.
 
-1. Firstly generate a secret and export it to an environmental variable:
-```sh
-export backend_secret=\
-$(node -p 'require("crypto").randomBytes(24).toString("base64")')
-```
 1. If you are running the app for the first time run:
-```sh
-# Install depedencies
-yarn install
 
-# Compile
-yarn tsc
-```
-3. Run the app with:
-```sh
-# Run with hot reload capabilities
-yarn dev
-```
-4. A tab in your default browser should appear if not by default, the app will be available on http://localhost:3000.
+    ```sh
+    # Install depedencies
+    yarn install
 
-## Run in a Kubernetes cluster
+    # Compile
+    yarn tsc
+    ```
+
+2. Run the app with:
+
+    ```sh
+    # Run with hot reload capabilities
+    yarn dev
+    ```
+
+3. A tab in your default browser should appear if not by default, the app will be available on http://localhost:3000.
+
+### Run in a Kubernetes cluster
+
 Configurations for the cluster dev setup are in `app-config.dev.yaml`.
-1. Generate a secret and copy it
-```sh
-echo -n "$(node -p 'require("crypto").randomBytes(24).toString("base64")')" | base64
-```
-2. Paste the secret into `manifests/base/secret` into `data.backend_secret`
-3. Update image repository URL with your image repository:
-```sh
-cd manifests/overlays/dev && kustomize edit set image quay.io/operate-first/service-catalog=<your url>
-```
-4. Deploy using
-```
-{oc,kubectl} apply -k manifests/overlays/dev
-```
+
+1. Update image repository URL with your image repository:
+
+    ```sh
+    cd manifests/overlays/dev && kustomize edit set image quay.io/operate-first/service-catalog=<your url>
+    ```
+
+2. Deploy using
+
+    ```sh
+    {oc,kubectl} apply -k manifests/overlays/dev
+    ```
 
 ### S2I image
+
 This repository uses s2i to create images. To create image run script located in `packages/backend`:
+
 ```sh
 ./packages/backend/build-image.sh
 ```
+
 This will generate an image called `service-catalog`, this image is aimed to be used in production so it needs access to PostgreSQL database. To run this image with podman run:
+
 ```sh
-podman run -it -p 7007:7007 --env "backend_secret=$(node -p 'require("crypto").randomBytes(24).toString("base64")')" service-catalog:latest
+export BACKEND_SECRET=$(node -p 'require("crypto").randomBytes(24).toString("base64")')
+podman run -it -p 7007:7007 --env "BACKEND_SECRET" service-catalog:latest
 ```

--- a/app-config.yaml
+++ b/app-config.yaml
@@ -26,7 +26,7 @@ backend:
   # information on the format
   auth:
     keys:
-      - secret: ${backend_secret}
+      - secret: ${BACKEND_SECRET}
   baseUrl: http://localhost:7007
   listen: 0.0.0.0:7007
   csp:

--- a/manifests/base/deployment.yaml
+++ b/manifests/base/deployment.yaml
@@ -16,8 +16,11 @@ spec:
         - name: service-catalog
           image: service-catalog
           command: ["node"]
-          args: []  # added by patch in overlays
-          imagePullPolicy: Always
+          args:
+            - packages/backend
+            - --config
+            - app-config.yaml
+            - --config
           ports:
             - containerPort: 7007
           envFrom:
@@ -26,15 +29,14 @@ spec:
             - secretRef:
                 name: service-catalog
           env:
-          - name: NODE_ENV
-            value: ""  # added by patch in overlays
+            - name: NODE_ENV
           volumeMounts:
-          - name: ca-cert
-            mountPath: "/mnt/certs"
+            - name: ca-cert
+              mountPath: "/mnt/certs"
       volumes:
-      - name: ca-cert
-        secret:
-          secretName: service-catalog-cluster-cert
-          items:
-          - key: ca.crt
-            path: ca.crt
+        - name: ca-cert
+          secret:
+            secretName: service-catalog-cluster-cert
+            items:
+              - key: ca.crt
+                path: ca.crt

--- a/manifests/overlays/dev/kustomization.yaml
+++ b/manifests/overlays/dev/kustomization.yaml
@@ -7,17 +7,18 @@ components:
   - ../../components/postgres-db
 patches:
   - patch: |
-      - op: replace
-        path: /spec/template/spec/containers/0/args
-        value: ["packages/backend", "--config", "app-config.yaml", "--config", "app-config.dev.yaml"]
-      - op: replace
+      - op: add
+        path: /spec/template/spec/containers/0/args/-
+        value: app-config.dev.yaml
+      - op: add
         path: /spec/template/spec/containers/0/env/0/value
-        value: "development"
+        value: development
     target:
       kind: Deployment
       name: service-catalog
 patchesStrategicMerge:
   - route.yaml
+  - secret.yaml
 images:
   - name: quay.io/operate-first/service-catalog
     newName:

--- a/manifests/overlays/dev/secret.yaml
+++ b/manifests/overlays/dev/secret.yaml
@@ -2,3 +2,5 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: service-catalog
+stringData:
+  BACKEND_SECRET: secret

--- a/manifests/overlays/prod/kustomization.yaml
+++ b/manifests/overlays/prod/kustomization.yaml
@@ -7,12 +7,12 @@ generators:
   - secret-generator.yaml
 patches:
   - patch: |
-      - op: replace
-        path: /spec/template/spec/containers/0/args
-        value: ["packages/backend", "--config", "app-config.yaml", "--config", "app-config.prod.yaml"]
-      - op: replace
+      - op: add
+        path: /spec/template/spec/containers/0/args/-
+        value: app-config.prod.yaml
+      - op: add
         path: /spec/template/spec/containers/0/env/0/value
-        value: "production"
+        value: production
     target:
       kind: Deployment
       name: service-catalog

--- a/manifests/overlays/prod/secret.enc.yaml
+++ b/manifests/overlays/prod/secret.enc.yaml
@@ -4,17 +4,16 @@ metadata:
     name: service-catalog
     annotations:
         kustomize.config.k8s.io/behavior: replace
-type: Opaque
-data:
-    backend_secret: ENC[AES256_GCM,data:7r+3vi7GO3f7OBejcCBFdVm/drEdjtOm0+ZzrenjGchDxSn7C65wYPJnptY=,iv:aUmcg4S7MkpdPG687OtDfOwvXqAE0lbpSZYp03W3zQg=,tag:LFFxb5DWnMmrEsyf3jW0uw==,type:str]
+stringData:
+    BACKEND_SECRET: ENC[AES256_GCM,data:5ZuDTp6HN/o2E68LUz9YbWUNAdtRwUqfw1wDVXRyMGs=,iv:D21drH7ECBCiaDMZTb+F/W/PsG87pXx2mfZD0XD3IIA=,tag:tPZ9IpIDKO1f/22Gpb0eBg==,type:str]
 sops:
     kms: []
     gcp_kms: []
     azure_kv: []
     hc_vault: []
     age: []
-    lastmodified: "2022-06-16T11:01:07Z"
-    mac: ENC[AES256_GCM,data:aZn/fhDvW1L2DnbtSxcA0mojHUQOFgNHmy+aJEgG+nJwhJ36CE4nrCSU5iM7sx/dqzBKyIPEeuK/0gORWJ0PY3uwCTa5q+h2+vE19W2XfFIlWg1YNmhpmDn+/9toTrw+CwkdCn7B6OoB2vDYeHTqT4Fzkm8VWl7OInrPXCjP8Hc=,iv:vDHDRNFdiszD2hw982O5GjpztOKM6bUkRdPGHz8rUB4=,tag:wiIjhXQ8aqsNrv4NcEWNzQ==,type:str]
+    lastmodified: "2022-07-07T10:05:05Z"
+    mac: ENC[AES256_GCM,data:dGkHFKkND4U6uIt5CJP3B52a7Ev+h3zivkCtrSWQ53AVYQPETRELi276E5vNcyBHUeSoELBVU2vls0G/OJR3Bha3cYARnc83LfkGy7Fhgf3ixgTjc4nHItVlOyw8kZnnDmC2sQrmbT5oQlcNif5UfeZNNwky8MaqKVoWJCEt2X4=,iv:UZxKPiS9QeZkRSdTPUgXisjMECc7wrDbK5xV6b93Cps=,tag:uKv7BXc0o46qhSFrMOa+8Q==,type:str]
     pgp:
         - created_at: "2022-06-16T11:01:07Z"
           enc: |-

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "node": "14 || 16"
   },
   "scripts": {
-    "dev": "concurrently \"yarn start\" \"yarn start-backend\"",
+    "dev": "BACKEND_SECRET=secret concurrently \"yarn start\" \"yarn start-backend\"",
     "start": "yarn workspace app start",
     "start-backend": "yarn workspace backend start",
     "build": "backstage-cli repo build --all",


### PR DESCRIPTION
Fixes:
- Markdown inconsistencies in README (linted via https://github.com/DavidAnson/markdownlint)
- Environment variable `backend_secret` converted to uppercase per env variable convention
- Overlays simplified
- `BACKEND_SECRET` set automatically in `yarn dev`