### PR TITLE
feat(security-insights): Remove secrity insights from the main view

### DIFF
--- a/packages/app/src/components/catalog/EntityPage.tsx
+++ b/packages/app/src/components/catalog/EntityPage.tsx
@@ -82,8 +82,6 @@ import {
   isGithubInsightsAvailable,
 } from '@roadiehq/backstage-plugin-github-insights';
 import {
-  EntitySecurityInsightsCard,
-  isSecurityInsightsAvailable,
   EntitySecurityInsightsContent,
 } from '@roadiehq/backstage-plugin-security-insights';
 import {
@@ -203,13 +201,6 @@ const overviewContent = (
     <Grid item md={8} xs={12}>
       <EntityHasSubcomponentsCard variant="gridItem" />
     </Grid>
-    <EntitySwitch>
-      <EntitySwitch.Case if={isSecurityInsightsAvailable}>
-        <Grid item md={6}>
-          <EntitySecurityInsightsCard />
-        </Grid>
-      </EntitySwitch.Case>
-    </EntitySwitch>
 
     <EntitySwitch>
       <EntitySwitch.Case if={e => Boolean(isGithubInsightsAvailable(e))}>


### PR DESCRIPTION
Since `security-insights` plugin requires rights to see security insights on a repository most people when looking at services won't have the required rights. I think the best solution is to remove it form the main overview screen of a service so errors don't pop up every time they load the page.