### PR TITLE
feat(k8s-plugin): Add service account for plugin

### DIFF
--- a/manifests/base/kustomization.yaml
+++ b/manifests/base/kustomization.yaml
@@ -7,6 +7,7 @@ resources:
   - route.yaml
   - secret.yaml
   - postgres.yaml
+  - serviceaccount.yaml
 images:
   - name: service-catalog
     newName: quay.io/operate-first/service-catalog

--- a/manifests/base/serviceaccount.yaml
+++ b/manifests/base/serviceaccount.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: service-catalog-k8s-plugin


### PR DESCRIPTION
Part of #12 

This service account is required by the `k8s plugin` and is required to merge before <put pr here> is merged so that the token can be encrypted into the production secret manifest.