### PR TITLE
feat(techdocs): Setup awsS3 as storage solution for techdocs publishing

### DIFF
--- a/app-config.prod.yaml
+++ b/app-config.prod.yaml
@@ -21,6 +21,20 @@ backend:
   cors:
     origin: https://service-catalog.operate-first.cloud
 
+techdocs:
+  builder: 'local'
+  generator:
+    runIn: 'local'
+  publisher:
+    type: 'awsS3'
+    awsS3:
+      bucketName: ${BUCKET_NAME}
+      region: ${BUKCET_REGION}
+      endpoint: https://${BUCKET_ENDPOINT}:${BUCKET_PORT}
+      credentials:
+        accessKeyId: ${AWS_ACCESS_KEY_ID}
+        secretAccessKey: ${AWS_SECRET_ACCESS_KEY}
+
 auth:
   environment: production
   providers:

--- a/app-config.yaml
+++ b/app-config.yaml
@@ -65,15 +65,12 @@ grafana:
   domain: https://grafana.operate-first.cloud
 
 # Reference documentation http://backstage.io/docs/features/techdocs/configuration
-# Note: After experimenting with basic setup, use CI/CD to generate docs
-# and an external cloud storage when deploying TechDocs for production use-case.
-# https://backstage.io/docs/features/techdocs/how-to-guides#how-to-migrate-from-techdocs-basic-to-recommended-deployment-approach
 techdocs:
-  builder: 'local'  # Alternatives - 'external'
+  builder: 'local'
   generator:
-    runIn: 'docker'  # Alternatives - 'local'
+    runIn: 'local'
   publisher:
-    type: 'local'  # Alternatives - 'googleGcs' or 'awsS3'. Read documentation for using alternatives.
+    type: 'local'
 
 catalog:
   rules:

--- a/manifests/overlays/prod/kustomization.yaml
+++ b/manifests/overlays/prod/kustomization.yaml
@@ -3,6 +3,7 @@ kind: Kustomization
 namespace: service-catalog
 resources:
   - ../../base
+  - obc.yaml
 generators:
   - secret-generator.yaml
 patches:
@@ -13,6 +14,16 @@ patches:
       - op: add
         path: /spec/template/spec/containers/0/env/0/value
         value: production
+      - op: add
+        path: /spec/template/spec/containers/0/envFrom/-
+        value:
+          secretRef:
+            name: service-catalog-bucket-claim
+      - op: add
+        path: /spec/template/spec/containers/0/envFrom/-
+        value:
+          configMapRef:
+            name: service-catalog-bucket-claim
     target:
       kind: Deployment
       name: service-catalog

--- a/manifests/overlays/prod/obc.yaml
+++ b/manifests/overlays/prod/obc.yaml
@@ -1,0 +1,7 @@
+apiVersion: objectbucket.io/v1alpha1
+kind: ObjectBucketClaim
+metadata:
+  name: service-catalog-bucket-claim
+spec:
+  generateBucketName: service-catalog-bucket-claim-
+  storageClassName: openshift-storage.noobaa.io


### PR DESCRIPTION
Part of #13

- Add creation of s3 bucket on prod deployment and configure the backstage publisher with the generated `secret`/`configMap`
- Switch default docs building to `local` for development setup