### PR TITLE
feat(techdocs): Add github workflows for publisher and listener

### DIFF
--- a/.github/actions/docs-dispatch/action.yaml
+++ b/.github/actions/docs-dispatch/action.yaml
@@ -1,0 +1,56 @@
+name: docs-dispatch
+inputs:
+  entity_name:
+    required: true
+  entity_kind:
+    required: true
+  entity_namespace:
+    required: false
+    default: 'default'
+  repository:
+    required: true
+    description: 'Repository that your documentation files are located at'
+  docs_path:
+    required: true
+    description: 'Directory path to your documentation folder relative to the repository root'
+  filter:
+    required: false
+    description: 'Glob expression filtering the changed files'
+    default: '.'
+  token:
+    required: true
+    description: 'GitHub token that requires metadata:read and contents:read&write permissions to target repository'
+
+runs:
+  using: 'composite'
+  steps:
+    - uses: actions/checkout@v2
+      with:
+        repository: ${{ inputs.repository }}
+
+    - uses: dorny/paths-filter@v2
+      id: changes
+      with:
+        filters: |
+          root_docs:
+            - 'docs/**'
+            - 'mkdocs.yaml'
+            - 'mkdocs.yml'
+          docs:
+            - '${{ inputs.filter }}'
+
+    - name: Send dispatch for root docs
+      if: (steps.changes.outputs.root_docs == 'true' && inputs.docs_path == '.') || steps.changes.outputs.docs == 'true'
+      run: |
+        curl -X POST \
+          -H "Accept: application/vnd.github+json" \
+          -H "Authorization: token ${{ inputs.token }}" \
+          https://api.github.com/repos/operate-first/service-catalog/dispatches \
+          -d '{"event_type":"docs-update","client_payload":{
+            "docs_path":"${{ inputs.docs_path }}",
+            "repository":"${{ inputs.repository }}",
+            "entity_name":"${{ inputs.entity_name }}",
+            "entity_kind":"${{ inputs.entity_kind }}",
+            "entity_namespace":"${{ inputs.entity_namespace }}"
+          }}'
+      shell: bash

--- a/.github/workflows/techdocs-generate-and-publish.yaml
+++ b/.github/workflows/techdocs-generate-and-publish.yaml
@@ -1,0 +1,65 @@
+name: Publish TechDocs Site
+
+on:
+  repository_dispatch:
+    types:
+      - docs-update
+
+jobs:
+  generate-and-publish:
+    runs-on: ubuntu-latest
+    env:
+      BUCKET_NAME: ${{ secrets.BUCKET_NAME }}
+      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+      AWS_ENDPOINT: https://s3-openshift-storage.apps.smaug.na.operate-first.cloud
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+    steps:
+      - name: Clone repo
+        uses: actions/checkout@v3
+        with:
+          repository: '${{ github.event.client_payload.repository }}'
+
+      - name: Setup node
+        uses: actions/setup-node@v2
+
+      - name: Setup python
+        uses: actions/setup-python@v2
+
+      - name: Setup Java
+        uses: actions/setup-java@v2
+        with:
+          distribution: 'zulu'
+          java-version: '11'
+
+      - name: download, validate, install plantuml and its dependencies
+        run: |
+          curl -o plantuml.jar -L http://sourceforge.net/projects/plantuml/files/plantuml.1.2021.4.jar/download
+          echo "be498123d20eaea95a94b174d770ef94adfdca18  plantuml.jar" | sha1sum -c -
+          mv plantuml.jar /opt/plantuml.jar
+          mkdir -p "$HOME/.local/bin"
+          echo $'#!/bin/sh\n\njava -jar '/opt/plantuml.jar' ${@}' >>  "$HOME/.local/bin/plantuml"
+          chmod +x "$HOME/.local/bin/plantuml"
+          echo "$HOME/.local/bin" >> $GITHUB_PATH
+          sudo apt-get install -y graphviz
+
+      - name: Install techdocs-cli
+        run: sudo npm install --location=global @techdocs/cli
+
+      - name: Install mkdocs and mkdocs plugins
+        run: python -m pip install mkdocs-techdocs-core==1.*
+
+      - name: Generate docs site
+        working-directory: ${{ github.event.client_payload.docs_path }}
+        run: techdocs-cli generate --no-docker --verbose
+
+      - name: Publish docs site
+        working-directory: ${{ github.event.client_payload.docs_path }}
+        run: |
+          echo ${{ github.event.client_payload.entity_namespace }}/${{ github.event.client_payload.entity_kind }}/${{ github.event.client_payload.entity_name }}
+
+          techdocs-cli publish \
+            --publisher-type awsS3 \
+            --storage-name $BUCKET_NAME \
+            --awsEndpoint $AWS_ENDPOINT \
+            --awsS3ForcePathStyle \
+            --entity ${{ github.event.client_payload.entity_namespace }}/${{ github.event.client_payload.entity_kind }}/${{ github.event.client_payload.entity_name }}

--- a/.github/workflows/techdocs.yaml
+++ b/.github/workflows/techdocs.yaml
@@ -1,0 +1,35 @@
+name: Send dispatch to publisher
+
+# This is a template for other repositories, uncomment this when applyting
+# this to a real service repository
+# on:
+#   push:
+#     branches:
+#       - main
+#       - master
+#     paths:
+#       - "**/docs/**"
+#       - "mkdocs.yaml"
+#       - "mkdocs.yml"
+
+jobs:
+  send-repo-dispatches:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Send dispatch for service2
+        uses: operate-first/service-catalog/.github/actions/docs-dispatch@main
+        with:
+          filter: 'service2/**'
+          docs_path: 'service2'
+          entity_name: 'service2'
+          entity_kind: 'Component'
+          repository: ${{ github.repository }}
+          token: ${{ secrets.SESHETA_TOKEN }}
+      - name: Send dispatch for service1
+        uses: operate-first/service-catalog/.github/actions/docs-dispatch@main
+        with:
+          docs_path: '.'
+          entity_name: 'service1'
+          entity_kind: 'Component'
+          repository: ${{ github.repository }}
+          token: ${{ secrets.SESHETA_TOKEN }}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,4 +1,5 @@
 ---
+exclude: '^.github'
 repos:
   - repo: https://github.com/Lucas-C/pre-commit-hooks
     rev: v1.1.9

--- a/app-config.prod.yaml
+++ b/app-config.prod.yaml
@@ -22,7 +22,7 @@ backend:
     origin: https://service-catalog.operate-first.cloud
 
 techdocs:
-  builder: 'local'
+  builder: 'external'
   generator:
     runIn: 'local'
   publisher:
@@ -30,7 +30,8 @@ techdocs:
     awsS3:
       bucketName: ${BUCKET_NAME}
       region: ${BUKCET_REGION}
-      endpoint: https://${BUCKET_ENDPOINT}:${BUCKET_PORT}
+      endpoint: https://s3-openshift-storage.apps.smaug.na.operate-first.cloud
+      s3ForcePathStyle: true
       credentials:
         accessKeyId: ${AWS_ACCESS_KEY_ID}
         secretAccessKey: ${AWS_SECRET_ACCESS_KEY}


### PR DESCRIPTION
Resolves #13

This implements the 2nd solution in the issue referenced above. It can handle multiple documentation directories, one for each service in a single repository.

The workflow `techdocs-publisher.yaml` would live in this repository and it would handle building&publishing of the documentation.

The second workflow `techdocs.yaml` is required to send the [dispatch](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#repository_dispatch) events to the publisher. We would add this workflow to repositories that host the documentation.