### PR TITLE
feat: Add common labels to manifests

### DIFF
--- a/manifests/base/deployment.yaml
+++ b/manifests/base/deployment.yaml
@@ -6,11 +6,11 @@ spec:
   replicas: 1
   selector:
     matchLabels:
-      app: service-catalog
+      app.kubernetes.io/component: app
   template:
     metadata:
       labels:
-        app: service-catalog
+        app.kubernetes.io/component: app
     spec:
       serviceAccountName: service-catalog-k8s-plugin
       containers:

--- a/manifests/base/kustomization.yaml
+++ b/manifests/base/kustomization.yaml
@@ -8,6 +8,9 @@ resources:
   - secret.yaml
   - postgres.yaml
   - serviceaccount.yaml
+commonLabels:
+  app.kubernetes.io/name: service-catalog
+  app.kubernetes.io/managed-by: sig-services
 images:
   - name: service-catalog
     newName: quay.io/operate-first/service-catalog


### PR DESCRIPTION
Part of #55

Add labels to manifests so that the k8s plugin can be utilized in the service catalog component.