### PR TITLE
feat: Add issue templates for service catalog

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -1,0 +1,27 @@
+name: Report Issue or Bug
+description: Create report of issue or bug
+title: <your-issue-title>
+body:
+  - type: textarea
+    id: description
+    attributes:
+      label: Describe the problem
+    validations:
+      required: true
+  - type: textarea
+    id: steps_to_reproduce
+    attributes:
+      label: Steps to reproduce the problem
+      placeholder: |
+        1. Go to '...'
+        2. Click on '....'
+        3. Scroll down to '....'
+        4. See error
+    validations:
+      required: true
+  - type: textarea
+    id: screenshots
+    attributes:
+      label: Screenshots
+      description: |
+        If applicable, add screenshots to help explain your problem.    

--- a/.github/ISSUE_TEMPLATE/feature_request.yaml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yaml
@@ -1,0 +1,27 @@
+name: Feature Request
+description: A feature request for the Service Catalog
+title: <your-feature-request-title>
+body:
+- type: textarea
+  id: context
+  attributes:
+    description: |
+      Please add any additional context for your story.
+    label: Additional context
+  validations:
+    required: true
+- type: textarea
+  id: criteria
+  attributes:
+    label: Acceptance Criteria
+    placeholder: |
+      - [ ] At least once acceptance criteria should be present
+  validations:
+    required: true
+- type: textarea
+  id: links
+  attributes:
+    label: Relevant links
+    description: |
+      Add any links to resources, issues, etc. that you feel are
+      relevant to this story.


### PR DESCRIPTION
Resolves #72 
For now I have created following issue templates:
- [X] Bug report
- [X] Feature request

If you think there should be any other templates present or you want some changes in current please let me know