### PR TITLE
fix: Resource limits for deployment

### DIFF
--- a/manifests/base/deployment.yaml
+++ b/manifests/base/deployment.yaml
@@ -57,6 +57,11 @@ spec:
           volumeMounts:
             - name: ca-cert
               mountPath: "/mnt/certs"
+          resources:
+            limits:
+              cpu: 300m
+            requests:
+              cpu: 200m
       volumes:
         - name: ca-cert
           secret:
@@ -64,8 +69,3 @@ spec:
             items:
               - key: ca.crt
                 path: ca.crt
-      resources:
-        limits:
-          cpu: 300m
-        requests:
-          cpu: 200m


### PR DESCRIPTION
Resource limits and requests are placed in the wrong path, fix this by placing them in `.spec.template.spec.containers[0]`.