### PR TITLE
fix: Reference the correct label in service manifest

### DIFF
--- a/manifests/base/service.yaml
+++ b/manifests/base/service.yaml
@@ -4,7 +4,7 @@ metadata:
   name: service-catalog
 spec:
   selector:
-    app: service-catalog
+    app.kubernetes.io/component: app
   ports:
     - port: 7007
       targetPort: 7007


### PR DESCRIPTION
Forgot to do this while changing the deployment labels, sorry about that.