### PR TITLE
feat: Add component logo to masthead

### DIFF
--- a/packages/app/src/components/catalog/EntityPage.tsx
+++ b/packages/app/src/components/catalog/EntityPage.tsx
@@ -31,7 +31,6 @@ import {
   EntityHasResourcesCard,
   EntityHasSubcomponentsCard,
   EntityHasSystemsCard,
-  EntityLayout,
   EntityLinksCard,
   EntitySwitch,
   EntityOrphanWarning,
@@ -94,7 +93,7 @@ import {
   isGrafanaAvailable
 } from '@k-phoen/backstage-plugin-grafana';
 import { EntityKubernetesContent } from '@backstage/plugin-kubernetes';
-
+import { EntityLayout } from '../entityLayout/EntityLayout'
 
 const EntityLayoutWrapper = (props: { children?: ReactNode }) => {
   const [badgesDialogOpen, setBadgesDialogOpen] = useState(false);

--- a/packages/app/src/components/entityLayout/EntityContextMenu.tsx
+++ b/packages/app/src/components/entityLayout/EntityContextMenu.tsx
@@ -1,0 +1,166 @@
+/*
+ * Copyright 2020 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+  Divider,
+  IconButton,
+  ListItemIcon,
+  ListItemText,
+  MenuItem,
+  MenuList,
+  Popover,
+} from '@material-ui/core';
+import { makeStyles } from '@material-ui/core/styles';
+import CancelIcon from '@material-ui/icons/Cancel';
+import BugReportIcon from '@material-ui/icons/BugReport';
+import MoreVert from '@material-ui/icons/MoreVert';
+import React, { useState } from 'react';
+import { IconComponent } from '@backstage/core-plugin-api';
+import { useEntityPermission } from './UseEntityPermissions';
+import { catalogEntityDeletePermission } from './permissions';
+import { BackstageTheme } from '@backstage/theme';
+
+/** @public */
+export type EntityContextMenuClassKey = 'button';
+
+const useStyles = makeStyles(
+  (theme: BackstageTheme) => {
+    return {
+      button: {
+        color: theme.palette.bursts.fontColor,
+      },
+    };
+  },
+  { name: 'PluginCatalogEntityContextMenu' },
+);
+
+// NOTE(freben): Intentionally not exported at this point, since it's part of
+// the unstable extra context menu items concept below
+interface ExtraContextMenuItem {
+  title: string;
+  Icon: IconComponent;
+  onClick: () => void;
+}
+
+// unstable context menu option, eg: disable the unregister entity menu
+interface contextMenuOptions {
+  disableUnregister: boolean;
+}
+
+interface EntityContextMenuProps {
+  UNSTABLE_extraContextMenuItems?: ExtraContextMenuItem[];
+  UNSTABLE_contextMenuOptions?: contextMenuOptions;
+  onUnregisterEntity: () => void;
+  onInspectEntity: () => void;
+}
+
+export function EntityContextMenu(props: EntityContextMenuProps) {
+  const {
+    UNSTABLE_extraContextMenuItems,
+    UNSTABLE_contextMenuOptions,
+    onUnregisterEntity,
+    onInspectEntity,
+  } = props;
+  const [anchorEl, setAnchorEl] = useState<HTMLButtonElement>();
+  const classes = useStyles();
+  const unregisterPermission = useEntityPermission(
+    catalogEntityDeletePermission,
+  );
+
+  const onOpen = (event: React.SyntheticEvent<HTMLButtonElement>) => {
+    setAnchorEl(event.currentTarget);
+  };
+
+  const onClose = () => {
+    setAnchorEl(undefined);
+  };
+
+  const extraItems = UNSTABLE_extraContextMenuItems && [
+    ...UNSTABLE_extraContextMenuItems.map(item => (
+      <MenuItem
+        key={item.title}
+        onClick={() => {
+          onClose();
+          item.onClick();
+        }}
+      >
+        <ListItemIcon>
+          <item.Icon fontSize="small" />
+        </ListItemIcon>
+        <ListItemText primary={item.title} />
+      </MenuItem>
+    )),
+    <Divider key="the divider is here!" />,
+  ];
+
+  const disableUnregister =
+    (!unregisterPermission.allowed ||
+      UNSTABLE_contextMenuOptions?.disableUnregister) ??
+    false;
+
+  return (
+    <>
+      <IconButton
+        aria-label="more"
+        aria-controls="long-menu"
+        aria-haspopup="true"
+        aria-expanded={!!anchorEl}
+        role="button"
+        onClick={onOpen}
+        data-testid="menu-button"
+        className={classes.button}
+        id="long-menu"
+      >
+        <MoreVert />
+      </IconButton>
+      <Popover
+        open={Boolean(anchorEl)}
+        onClose={onClose}
+        anchorEl={anchorEl}
+        anchorOrigin={{ vertical: 'bottom', horizontal: 'right' }}
+        transformOrigin={{ vertical: 'top', horizontal: 'right' }}
+        aria-labelledby="long-menu"
+      >
+        <MenuList>
+          {extraItems}
+          <MenuItem
+            onClick={() => {
+              onClose();
+              onUnregisterEntity();
+            }}
+            disabled={disableUnregister}
+          >
+            <ListItemIcon>
+              <CancelIcon fontSize="small" />
+            </ListItemIcon>
+            <ListItemText primary="Unregister entity" />
+          </MenuItem>
+          <MenuItem
+            onClick={() => {
+              onClose();
+              onInspectEntity();
+            }}
+          >
+            <ListItemIcon>
+              <BugReportIcon fontSize="small" />
+            </ListItemIcon>
+            <ListItemText primary="Inspect entity" />
+          </MenuItem>
+        </MenuList>
+      </Popover>
+    </>
+  );
+}

--- a/packages/app/src/components/entityLayout/EntityLayout.tsx
+++ b/packages/app/src/components/entityLayout/EntityLayout.tsx
@@ -1,0 +1,299 @@
+/*
+ * Copyright 2020 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+  Entity,
+  DEFAULT_NAMESPACE,
+  RELATION_OWNED_BY,
+} from '@backstage/catalog-model';
+import {
+  Content,
+  Header,
+  HeaderLabel,
+  Link,
+  Page,
+  Progress,
+  RoutedTabs,
+  WarningPanel,
+} from '@backstage/core-components';
+import {
+  attachComponentData,
+  IconComponent,
+  useElementFilter,
+  useRouteRefParams,
+} from '@backstage/core-plugin-api';
+import {
+  EntityRefLinks,
+  entityRouteRef,
+  FavoriteEntity,
+  getEntityRelations,
+  InspectEntityDialog,
+  UnregisterEntityDialog,
+  useAsyncEntity,
+} from '@backstage/plugin-catalog-react';
+import { Box, TabProps } from '@material-ui/core';
+import { Alert } from '@material-ui/lab';
+import React, { useEffect, useState } from 'react';
+import { useLocation, useNavigate } from 'react-router';
+import { EntityContextMenu } from './EntityContextMenu';
+
+/** @public */
+export type EntityLayoutRouteProps = {
+  path: string;
+  title: string;
+  children: JSX.Element;
+  if?: (entity: Entity) => boolean;
+  tabProps?: TabProps<React.ElementType, { component?: React.ElementType }>;
+};
+
+const dataKey = 'plugin.catalog.entityLayoutRoute';
+
+const Route: (props: EntityLayoutRouteProps) => null = () => null;
+attachComponentData(Route, dataKey, true);
+attachComponentData(Route, 'core.gatherMountPoints', true); // This causes all mount points that are discovered within this route to use the path of the route itself
+
+function EntityLayoutTitle(props: {
+  title: string;
+  entity: Entity | undefined;
+}) {
+  const { entity, title } = props;
+  return (
+    <Box display="inline-flex" alignItems="center" height="1em" maxWidth="100%">
+      <Box
+        component="span"
+        textOverflow="ellipsis"
+        whiteSpace="nowrap"
+        overflow="hidden"
+      >
+        {title}
+      </Box>
+      {entity && <FavoriteEntity entity={entity} />}
+    </Box>
+  );
+}
+
+function headerProps(
+  paramKind: string | undefined,
+  paramNamespace: string | undefined,
+  paramName: string | undefined,
+  entity: Entity | undefined,
+): { headerTitle: string; headerType: string } {
+  const kind = paramKind ?? entity?.kind ?? '';
+  const namespace = paramNamespace ?? entity?.metadata.namespace ?? '';
+  const name =
+    entity?.metadata.title ?? paramName ?? entity?.metadata.name ?? '';
+  return {
+    headerTitle: `${name}${
+      namespace && namespace !== DEFAULT_NAMESPACE ? ` in ${namespace}` : ''
+    }`,
+    headerType: (() => {
+      let t = kind.toLocaleLowerCase('en-US');
+      if (entity && entity.spec && 'type' in entity.spec) {
+        t += ' — ';
+        t += (entity.spec as { type: string }).type.toLocaleLowerCase('en-US');
+      }
+      return t;
+    })(),
+  };
+}
+
+function EntityLabels(props: { entity: Entity }) {
+  const { entity } = props;
+  const ownedByRelations = getEntityRelations(entity, RELATION_OWNED_BY);
+  return (
+    <>
+      {ownedByRelations.length > 0 && (
+        <HeaderLabel
+          label="Owner"
+          value={
+            <EntityRefLinks
+              entityRefs={ownedByRelations}
+              defaultKind="Group"
+              color="inherit"
+            />
+          }
+        />
+      )}
+      {entity.spec?.lifecycle && (
+        <HeaderLabel label="Lifecycle" value={entity.spec.lifecycle} />
+      )}
+    </>
+  );
+}
+
+// NOTE(freben): Intentionally not exported at this point, since it's part of
+// the unstable extra context menu items concept below
+interface ExtraContextMenuItem {
+  title: string;
+  Icon: IconComponent;
+  onClick: () => void;
+}
+
+// unstable context menu option, eg: disable the unregister entity menu
+interface contextMenuOptions {
+  disableUnregister: boolean;
+}
+
+/** @public */
+export interface EntityLayoutProps {
+  UNSTABLE_extraContextMenuItems?: ExtraContextMenuItem[];
+  UNSTABLE_contextMenuOptions?: contextMenuOptions;
+  children?: React.ReactNode;
+  NotFoundComponent?: React.ReactNode;
+}
+
+/**
+ * EntityLayout is a compound component, which allows you to define a layout for
+ * entities using a sub-navigation mechanism.
+ *
+ * Consists of two parts: EntityLayout and EntityLayout.Route
+ *
+ * @example
+ * ```jsx
+ * <EntityLayout>
+ *   <EntityLayout.Route path="/example" title="Example tab">
+ *     <div>This is rendered under /example/anything-here route</div>
+ *   </EntityLayout.Route>
+ * </EntityLayout>
+ * ```
+ *
+ * @public
+ */
+export const EntityLayout = (props: EntityLayoutProps) => {
+  const {
+    UNSTABLE_extraContextMenuItems,
+    UNSTABLE_contextMenuOptions,
+    children,
+    NotFoundComponent,
+  } = props;
+  const { kind, namespace, name } = useRouteRefParams(entityRouteRef);
+  const { entity, loading, error } = useAsyncEntity();
+  const location = useLocation();
+  const routes = useElementFilter(
+    children,
+    elements =>
+      elements
+        .selectByComponentData({
+          key: dataKey,
+          withStrictError:
+            'Child of EntityLayout must be an EntityLayout.Route',
+        })
+        .getElements<EntityLayoutRouteProps>() // all nodes, element data, maintain structure or not?
+        .flatMap(({ props: elementProps }) => {
+          if (!entity) {
+            return [];
+          } else if (elementProps.if && !elementProps.if(entity)) {
+            return [];
+          }
+
+          return [
+            {
+              path: elementProps.path,
+              title: elementProps.title,
+              children: elementProps.children,
+              tabProps: elementProps.tabProps,
+            },
+          ];
+        }),
+    [entity],
+  );
+
+  const { headerTitle, headerType } = headerProps(
+    kind,
+    namespace,
+    name,
+    entity,
+  );
+
+  const [confirmationDialogOpen, setConfirmationDialogOpen] = useState(false);
+  const [inspectionDialogOpen, setInspectionDialogOpen] = useState(false);
+  const navigate = useNavigate();
+  const cleanUpAfterRemoval = async () => {
+    setConfirmationDialogOpen(false);
+    setInspectionDialogOpen(false);
+    navigate('/');
+  };
+
+  // Make sure to close the dialog if the user clicks links in it that navigate
+  // to another entity.
+  useEffect(() => {
+    setConfirmationDialogOpen(false);
+    setInspectionDialogOpen(false);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [location.pathname]);
+
+  return (
+    <Page themeId={entity?.spec?.type?.toString() ?? 'home'}>
+      <Header
+        title={<EntityLayoutTitle title={headerTitle} entity={entity!} />}
+        pageTitleOverride={headerTitle}
+        type={headerType}
+      >
+        {entity && (
+          <>
+            <EntityLabels entity={entity} />
+            <EntityContextMenu
+              UNSTABLE_extraContextMenuItems={UNSTABLE_extraContextMenuItems}
+              UNSTABLE_contextMenuOptions={UNSTABLE_contextMenuOptions}
+              onUnregisterEntity={() => setConfirmationDialogOpen(true)}
+              onInspectEntity={() => setInspectionDialogOpen(true)}
+            />
+          </>
+        )}
+      </Header>
+
+      {loading && <Progress />}
+
+      {entity && <RoutedTabs routes={routes} />}
+
+      {error && (
+        <Content>
+          <Alert severity="error">{error.toString()}</Alert>
+        </Content>
+      )}
+
+      {!loading && !error && !entity && (
+        <Content>
+          {NotFoundComponent ? (
+            NotFoundComponent
+          ) : (
+            <WarningPanel title="Entity not found">
+              There is no {kind} with the requested{' '}
+              <Link to="https://backstage.io/docs/features/software-catalog/references">
+                kind, namespace, and name
+              </Link>
+              .
+            </WarningPanel>
+          )}
+        </Content>
+      )}
+
+      <UnregisterEntityDialog
+        open={confirmationDialogOpen}
+        entity={entity!}
+        onConfirm={cleanUpAfterRemoval}
+        onClose={() => setConfirmationDialogOpen(false)}
+      />
+      <InspectEntityDialog
+        open={inspectionDialogOpen}
+        entity={entity!}
+        onClose={() => setInspectionDialogOpen(false)}
+      />
+    </Page>
+  );
+};
+
+EntityLayout.Route = Route;

--- a/packages/app/src/components/entityLayout/EntityLayout.tsx
+++ b/packages/app/src/components/entityLayout/EntityLayout.tsx
@@ -44,11 +44,12 @@ import {
   UnregisterEntityDialog,
   useAsyncEntity,
 } from '@backstage/plugin-catalog-react';
-import { Box, TabProps } from '@material-ui/core';
+import { Box, makeStyles, TabProps } from '@material-ui/core';
 import { Alert } from '@material-ui/lab';
 import React, { useEffect, useState } from 'react';
 import { useLocation, useNavigate } from 'react-router';
 import { EntityContextMenu } from './EntityContextMenu';
+import { ICON_ANNOTATION } from '../../constants';
 
 /** @public */
 export type EntityLayoutRouteProps = {
@@ -65,6 +66,18 @@ const Route: (props: EntityLayoutRouteProps) => null = () => null;
 attachComponentData(Route, dataKey, true);
 attachComponentData(Route, 'core.gatherMountPoints', true); // This causes all mount points that are discovered within this route to use the path of the route itself
 
+const useCatalogStyles = makeStyles({
+  icon: {
+    '& img': {
+      height: 45,
+      width: 45,
+      objectFit: 'contain',
+      marginTop: 10,
+      marginRight: 10
+    },
+  },
+});
+
 function EntityLayoutTitle(props: {
   title: string;
   entity: Entity | undefined;
@@ -72,6 +85,12 @@ function EntityLayoutTitle(props: {
   const { entity, title } = props;
   return (
     <Box display="inline-flex" alignItems="center" height="1em" maxWidth="100%">
+      <Box className={useCatalogStyles().icon}>
+        <img
+          alt={`${entity?.metadata.name} logo`}
+          src={entity?.metadata.annotations?.[ICON_ANNOTATION]}
+        />
+      </Box>
       <Box
         component="span"
         textOverflow="ellipsis"

--- a/packages/app/src/components/entityLayout/UseEntityPermissions.ts
+++ b/packages/app/src/components/entityLayout/UseEntityPermissions.ts
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2022 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { stringifyEntityRef } from '@backstage/catalog-model';
+import { ResourcePermission } from '@backstage/plugin-permission-common';
+import { usePermission } from '@backstage/plugin-permission-react';
+import { useAsyncEntity } from './useEntity';
+
+/**
+ * A thin wrapper around the
+ * {@link @backstage/plugin-permission-react#usePermission} hook which uses the
+ * current entity in context to make an authorization request for the given
+ * {@link @backstage/plugin-catalog-common#CatalogEntityPermission}.
+ *
+ * Note: this hook blocks the permission request until the entity has loaded in
+ * context. If you have the entityRef and need concurrent requests, use the
+ * `usePermission` hook directly.
+ * @alpha
+ */
+export function useEntityPermission(
+  // TODO(joeporpeglia) Replace with `CatalogEntityPermission` when the issue described in
+  // https://github.com/backstage/backstage/pull/10128 is fixed.
+  permission: ResourcePermission<'catalog-entity'>,
+): {
+  loading: boolean;
+  allowed: boolean;
+  error?: Error;
+} {
+  const {
+    entity,
+    loading: loadingEntity,
+    error: entityError,
+  } = useAsyncEntity();
+  const {
+    allowed,
+    loading: loadingPermission,
+    error: permissionError,
+  } = usePermission({
+    permission,
+    resourceRef: entity ? stringifyEntityRef(entity) : undefined,
+  });
+
+  if (loadingEntity || loadingPermission) {
+    return { loading: true, allowed: false };
+  }
+  if (entityError) {
+    return { loading: false, allowed: false, error: entityError };
+  }
+  return { loading: false, allowed, error: permissionError };
+}

--- a/packages/app/src/components/entityLayout/permissions.ts
+++ b/packages/app/src/components/entityLayout/permissions.ts
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2021 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { createPermission } from '@backstage/plugin-permission-common';
+
+/**
+ * Permission resource type which corresponds to catalog entities.
+ *
+ * {@link https://backstage.io/docs/features/software-catalog/software-catalog-overview}
+ * @alpha
+ */
+export const RESOURCE_TYPE_CATALOG_ENTITY = 'catalog-entity';
+
+/**
+ * This permission is used to designate actions that involve removing one or
+ * more entities from the catalog.
+ * @alpha
+ */
+export const catalogEntityDeletePermission = createPermission({
+  name: 'catalog.entity.delete',
+  attributes: {
+    action: 'delete',
+  },
+  resourceType: RESOURCE_TYPE_CATALOG_ENTITY,
+});

--- a/packages/app/src/components/entityLayout/useEntity.tsx
+++ b/packages/app/src/components/entityLayout/useEntity.tsx
@@ -1,0 +1,152 @@
+/*
+ * Copyright 2020 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { Entity } from '@backstage/catalog-model';
+import {
+  createVersionedContext,
+  createVersionedValueMap,
+  useVersionedContext,
+} from '@backstage/version-bridge';
+import React, { ReactNode } from 'react';
+
+/** @public */
+export type EntityLoadingStatus<TEntity extends Entity = Entity> = {
+  entity?: TEntity;
+  loading: boolean;
+  error?: Error;
+  refresh?: VoidFunction;
+};
+
+// This context has support for multiple concurrent versions of this package.
+// It is currently used in parallel with the old context in order to provide
+// a smooth transition, but will eventually be the only context we use.
+const NewEntityContext = createVersionedContext<{ 1: EntityLoadingStatus }>(
+  'entity-context',
+);
+
+/**
+ * Properties for the AsyncEntityProvider component.
+ *
+ * @public
+ */
+export interface AsyncEntityProviderProps {
+  children: ReactNode;
+  entity?: Entity;
+  loading: boolean;
+  error?: Error;
+  refresh?: VoidFunction;
+}
+
+/**
+ * Provides a loaded entity to be picked up by the `useEntity` hook.
+ *
+ * @public
+ */
+export const AsyncEntityProvider = ({
+  children,
+  entity,
+  loading,
+  error,
+  refresh,
+}: AsyncEntityProviderProps) => {
+  const value = { entity, loading, error, refresh };
+  // We provide both the old and the new context, since
+  // consumers might be doing things like `useContext(EntityContext)`
+  return (
+    <NewEntityContext.Provider value={createVersionedValueMap({ 1: value })}>
+      {children}
+    </NewEntityContext.Provider>
+  );
+};
+
+/**
+ * Properties for the EntityProvider component.
+ *
+ * @public
+ */
+export interface EntityProviderProps {
+  children: ReactNode;
+  entity?: Entity;
+}
+
+/**
+ * Provides an entity to be picked up by the `useEntity` hook.
+ *
+ * @public
+ */
+export const EntityProvider = (props: EntityProviderProps) => (
+  <AsyncEntityProvider
+    entity={props.entity}
+    loading={!Boolean(props.entity)}
+    error={undefined}
+    refresh={undefined}
+    children={props.children}
+  />
+);
+
+/**
+ * Grab the current entity from the context, throws if the entity has not yet been loaded
+ * or is not available.
+ *
+ * @public
+ */
+export function useEntity<TEntity extends Entity = Entity>(): {
+  entity: TEntity;
+} {
+  const versionedHolder = useVersionedContext<{ 1: EntityLoadingStatus }>(
+    'entity-context',
+  );
+
+  if (!versionedHolder) {
+    throw new Error('Entity context is not available');
+  }
+
+  const value = versionedHolder.atVersion(1);
+  if (!value) {
+    throw new Error('EntityContext v1 not available');
+  }
+
+  if (!value.entity) {
+    throw new Error(
+      'useEntity hook is being called outside of an EntityLayout where the entity has not been loaded. If this is intentional, please use useAsyncEntity instead.',
+    );
+  }
+
+  return { entity: value.entity as TEntity };
+}
+
+/**
+ * Grab the current entity from the context, provides loading state and errors, and the ability to refresh.
+ *
+ * @public
+ */
+export function useAsyncEntity<
+  TEntity extends Entity = Entity,
+>(): EntityLoadingStatus<TEntity> {
+  const versionedHolder = useVersionedContext<{ 1: EntityLoadingStatus }>(
+    'entity-context',
+  );
+
+  if (!versionedHolder) {
+    throw new Error('Entity context is not available');
+  }
+  const value = versionedHolder.atVersion(1);
+  if (!value) {
+    throw new Error('EntityContext v1 not available');
+  }
+
+  const { entity, loading, error, refresh } = value;
+  return { entity: entity as TEntity, loading, error, refresh };
+}

--- a/packages/app/src/components/home/HomePage.tsx
+++ b/packages/app/src/components/home/HomePage.tsx
@@ -23,6 +23,7 @@ import useDebounce from 'react-use/lib/useDebounce';
 import { useApi } from '@backstage/core-plugin-api';
 import { Entity } from '@backstage/catalog-model';
 import Logo from '../Logo/Logo';
+import { ICON_ANNOTATION } from '../../constants'
 
 const useStyles = makeStyles(theme => ({
   searchBar: {
@@ -73,7 +74,6 @@ const useCatalogStyles = makeStyles({
     },
   },
 });
-const ICON_ANNOTATION = 'operate-first.cloud/logo-url';
 
 const CatalogCards = () => {
   const catalogApi = useApi(catalogApiRef);

--- a/packages/app/src/constants.ts
+++ b/packages/app/src/constants.ts
@@ -1,0 +1,1 @@
+export const ICON_ANNOTATION = 'operate-first.cloud/logo-url';


### PR DESCRIPTION
Resolves #53 

Add component logo to the masthead. This works by copying over the upstream source code for [`EntityLayout.tsx`](https://github.com/backstage/backstage/blob/master/plugins/catalog/src/components/EntityLayout/EntityLayout.tsx) and its dependencies. Then the code is edited to add the component logo. See the image below.

Also add a [constants file](https://github.com/operate-first/service-catalog/pull/87/commits/ccd9253c095f7e0c20b6dd14181d6ebea5cbab00) for `ICON_ANNOTATION`.

![image](https://user-images.githubusercontent.com/44006847/184664909-20560244-be3e-48ce-a69c-c7740f21c6b1.png)

You can check the last commit to see how the logo is implemented, the first commit is just copy pasting stuff from backstage upstream.