### PR TITLE
feat: Allow raw github content

### DIFF
--- a/app-config.yaml
+++ b/app-config.yaml
@@ -47,6 +47,7 @@ backend:
   reading:
     allow:
       - host: 'argocd.operate-first.cloud'
+      - host: 'raw.githubusercontent.com'
 
 proxy:
   '/argocd/api':


### PR DESCRIPTION
Needed change for https://github.com/operate-first/apps/pull/2205, more specifically the Grafana API reference.