### PR TITLE
chore: Fix entity name for the new catalog layout

### DIFF
--- a/.github/workflows/techdocs.yaml
+++ b/.github/workflows/techdocs.yaml
@@ -17,7 +17,7 @@ jobs:
         uses: operate-first/service-catalog/.github/actions/docs-dispatch@main
         with:
           docs_path: '.'
-          entity_name: 'service-catalog'
+          entity_name: 'backstage'
           entity_kind: 'Component'
           repository: ${{ github.repository }}
           token: ${{ secrets.SESHETA_TOKEN }}


### PR DESCRIPTION
By creating a new entity setup we changed the catalog entity name from `service-catalog` to `backstage`. We need to reflect that change in the workflow that sends dispatch to build documentation.