### PR TITLE
fix: Reduce db backup retention, increase storage size

### DIFF
--- a/manifests/base/postgres.yaml
+++ b/manifests/base/postgres.yaml
@@ -12,7 +12,7 @@ spec:
         - "ReadWriteOnce"
         resources:
           requests:
-            storage: 1Gi
+            storage: 2Gi
       resources:
         limits:
           cpu: 300m
@@ -23,7 +23,7 @@ spec:
       image: registry.developers.crunchydata.com/crunchydata/crunchy-pgbackrest:ubi8-2.38-0
       global:
         # Save backups for 14 days, this means 2 full backups with 6 differential ones in between
-        repo1-retention-full: "14"
+        repo1-retention-full: "7"
         repo1-retention-full-type: count
       repoHost:
         resources:
@@ -44,7 +44,7 @@ spec:
             - "ReadWriteOnce"
             resources:
               requests:
-                storage: 1Gi
+                storage: 2Gi
   users:
     - name: service-catalog
       options: "SUPERUSER"


### PR DESCRIPTION
The database got filed up again since the backups were too big in size.

- Reduce retention policy to 7 days
- Increase storage size from `1 Gi` to `2 Gi`

Hopefully this should prevent any future problems with the storage and database.