### PR TITLE
chore: Change example service name

### DIFF
--- a/docs/configuring-entities.md
+++ b/docs/configuring-entities.md
@@ -46,7 +46,7 @@ mkdocs.yaml
 This default setup above is the most common use case when you have one documentation per one entity repository. However it is also posible to have multiple documentations for multiple entities in one repository. Each documented entity has to be contained in one directory. See the example below:
 
 ```
-service1/
+service2/
 ├── docs/
 │   └── index.md
 ├── mkdocs.yaml


### PR DESCRIPTION
Mainly this change is for re triggering the dispatch event to build docs for the correct component.

`Service2` is used later in the documentation, so it makes more sense to use the same service as an example here. 