### PR TITLE
feat: Create script for k8s plugin cronjob

### DIFF
--- a/cronjob/Dockerfile
+++ b/cronjob/Dockerfile
@@ -1,0 +1,5 @@
+FROM quay.io/operate-first/opf-toolbox
+
+COPY ./upload-token.sh .
+
+CMD ["./upload-token.sh"]

--- a/cronjob/upload-token-to-vault.sh
+++ b/cronjob/upload-token-to-vault.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+echo "Authenticating with vault using SA JWT token ..."
+VAULT_AUTH_TOKEN=$(oc sa get-token vault-secret-fetcher -n service-catalog-k8s-plugin)
+VAULT_CLIENT_TOKEN=$(vault write auth/$CLUSTER-k8s/login role=$ENV-ops jwt="$VAULT_AUTH_TOKEN" -format=json | jq -r '.auth.client_token')
+vault login -no-print $VAULT_CLIENT_TOKEN
+
+# Push SA token to vault
+echo "Pushing k8s plugin SA token to vault ..."
+K8S_PLUGIN_TOKEN=$(oc sa get-token service-catalog-k8s-plugin -n service-catalog-k8s-plugin)
+vault kv put -mount=k8s_secrets $ENV/$CLUSTER/service-catalog-k8s-plugin token=$K8S_PLUGIN_TOKEN


### PR DESCRIPTION
Work in progress

Part of #59, https://github.com/operate-first/apps/pull/2344

Create a `Dockerfile` and a bash script that will be run via a `CronJob` in `operate-first/apps` repo.

The bash script firstly authenticates to our vault instance via the SA `vault-secret-fetcher` that will be present in the `service-catalog-k8s-plugin` namespace. After that it uploads the token for SA that will be used with the k8s plugin.

[Documentation for logging in with vault CLI](https://github.com/operate-first/apps/pull/2334)