### PR TITLE
feat: Add configs for all clusters to prod

### DIFF
--- a/app-config.prod.yaml
+++ b/app-config.prod.yaml
@@ -55,7 +55,56 @@ kubernetes:
           authProvider: 'serviceAccount'
           skipTLSVerify: false
           skipMetricsLookup: false
-          # The plugin will automatically use the auto mounted token
-          # serviceAccountToken: ${SERVICE_ACCOUNT_TOKEN}
+          serviceAccountToken: ${moc_smaug_token}
           dashboardUrl: https://console-openshift-console.apps.smaug.na.operate-first.cloud
+          dashboardApp: openshift
+    - type: 'config'
+      clusters:
+        - url: https://api.moc-infra.massopen.cloud:6443
+          name: infra
+          authProvider: 'serviceAccount'
+          skipTLSVerify: false
+          skipMetricsLookup: false
+          serviceAccountToken: ${moc_infra_token}
+          dashboardUrl: https://console-openshift-console.apps.moc-infra.massopen.cloud
+          dashboardApp: openshift
+    - type: 'config'
+      clusters:
+        - url: https://api.curator.massopen.cloud:6443
+          name: curator
+          authProvider: 'serviceAccount'
+          skipTLSVerify: false
+          skipMetricsLookup: false
+          serviceAccountToken: ${moc_curator_token}
+          dashboardUrl: https://console-openshift-console.apps.curator.massopen.cloud
+          dashboardApp: openshift
+    - type: 'config'
+      clusters:
+        - url: https://api.balrog.aws.operate-first.cloud:6443
+          name: balrog
+          authProvider: 'serviceAccount'
+          skipTLSVerify: false
+          skipMetricsLookup: false
+          serviceAccountToken: ${emea_balrog_token}
+          dashboardUrl: https://console-openshift-console.apps.balrog.aws.operate-first.cloud
+          dashboardApp: openshift
+    - type: 'config'
+      clusters:
+        - url: https://api.odh-cl1.apps.os-climate.org:6443
+          name: osc-cl1
+          authProvider: 'serviceAccount'
+          skipTLSVerify: false
+          skipMetricsLookup: false
+          serviceAccountToken: ${osc_osc-cl1_token}
+          dashboardUrl: https://console-openshift-console.apps.odh-cl1.apps.os-climate.org
+          dashboardApp: openshift
+    - type: 'config'
+      clusters:
+        - url: https://api.odh-cl2.apps.os-climate.org:6443
+          name: osc-cl2
+          authProvider: 'serviceAccount'
+          skipTLSVerify: false
+          skipMetricsLookup: false
+          serviceAccountToken: ${osc_osc-cl2_token}
+          dashboardUrl: https://console-openshift-console.apps.odh-cl2.apps.os-climate.org
           dashboardApp: openshift

--- a/manifests/base/deployment.yaml
+++ b/manifests/base/deployment.yaml
@@ -2,6 +2,8 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: service-catalog
+  annotations:
+    secret.reloader.stakater.com/reload: "service-catalog-k8s-plugin-tokens"
 spec:
   replicas: 1
   selector:
@@ -12,7 +14,6 @@ spec:
       labels:
         app.kubernetes.io/component: app
     spec:
-      serviceAccountName: service-catalog-k8s-plugin
       containers:
         - name: service-catalog
           image: service-catalog
@@ -27,6 +28,8 @@ spec:
           envFrom:
             - secretRef:
                 name: service-catalog-pguser-service-catalog
+            - secretRef:
+                name: service-catalog-k8s-plugin-tokens
           env:
             - name: NODE_ENV
             - name: BACKEND_SECRET


### PR DESCRIPTION
Part of #59 

- Add tokens secret to deployment.
- Add configurations for our manged clusters to prod app config overlay 
- Reloader is already deployed at [here](https://console-openshift-console.apps.smaug.na.operate-first.cloud/k8s/ns/reloader/pods) so I don't think I need to do any setup at apps repo.