### PR TITLE
chore: Simplify local dev config a bit

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -18,3 +18,7 @@ GRAFANA_TOKEN=
 # | jq -r '.data["token"]' \
 # | base64 --decode
 SERVICE_ACCOUNT_TOKEN=
+
+# Path to catalog files relative to this repository root, e.g.:
+# CATALOG_LOCAL_PATH=../apps/service-catalog/all.yaml
+CATALOG_LOCAL_PATH=

--- a/app-config.dev.yaml
+++ b/app-config.dev.yaml
@@ -21,15 +21,20 @@ backend:
   cors:
     origin: <url>
 
+catalog:
+  locations:
+    - type: url
+      target: https://github.com/operate-first/apps/blob/master/service-catalog/all.yaml
+
 kubernetes:
   serviceLocatorMethod:
-    type: 'multiTenant'
+    type: "multiTenant"
   clusterLocatorMethods:
-    - type: 'config'
+    - type: "config"
       clusters:
         - url: https://openshift.default.svc.cluster.local
           name: dev-cluster
-          authProvider: 'serviceAccount'
+          authProvider: "serviceAccount"
           skipTLSVerify: true
           skipMetricsLookup: false
           # Uncomment this if you want to use a different url other then the local one

--- a/app-config.local.yaml
+++ b/app-config.local.yaml
@@ -11,33 +11,34 @@ backend:
     credentials: true
   database:
     client: better-sqlite3
-    connection: ':memory:'
+    connection: ":memory:"
 
 catalog:
-  rules:
-    - allow:
-        - Component
-        - System
-        - Location
-        - User
-        - Group
   locations:
     - type: file
-      target: ../../examples/all.yaml
+      target: ../../${CATALOG_LOCAL_PATH}
     #  Uncomment to use defintions files from apps repo
     # - type: url
     #   target: https://github.com/operate-first/apps/blob/master/service-catalog/all.yaml
 
+auth:
+  environment: development
+  providers:
+    github:
+      development:
+        clientId: ${AUTH_GITHUB_CLIENT_ID}
+        clientSecret: ${AUTH_GITHUB_CLIENT_SECRET}
+
 kubernetes:
   serviceLocatorMethod:
-    type: 'multiTenant'
+    type: "multiTenant"
   clusterLocatorMethods:
-    - type: 'config'
+    - type: "config"
       clusters:
         # This is using kubectl proxy which is started in the yarn dev script
         - url: http://localhost:8001
           name: dev-cluster
-          authProvider: 'serviceAccount'
+          authProvider: "serviceAccount"
           skipTLSVerify: false
           skipMetricsLookup: false
           # If you are not signed in to your cluster, use a Service Account token

--- a/app-config.prod.yaml
+++ b/app-config.prod.yaml
@@ -22,11 +22,11 @@ backend:
     origin: https://service-catalog.operate-first.cloud
 
 techdocs:
-  builder: 'external'
+  builder: "external"
   generator:
-    runIn: 'local'
+    runIn: "local"
   publisher:
-    type: 'awsS3'
+    type: "awsS3"
     awsS3:
       bucketName: ${BUCKET_NAME}
       region: ${BUKCET_REGION}
@@ -44,15 +44,20 @@ auth:
         clientId: ${AUTH_GITHUB_CLIENT_ID}
         clientSecret: ${AUTH_GITHUB_CLIENT_SECRET}
 
+catalog:
+  locations:
+    - type: url
+      target: https://github.com/operate-first/apps/blob/master/service-catalog/all.yaml
+
 kubernetes:
   serviceLocatorMethod:
-    type: 'multiTenant'
+    type: "multiTenant"
   clusterLocatorMethods:
-    - type: 'config'
+    - type: "config"
       clusters:
         - url: https://api.smaug.na.operate-first.cloud:6443
           name: smaug
-          authProvider: 'serviceAccount'
+          authProvider: "serviceAccount"
           skipTLSVerify: false
           skipMetricsLookup: false
           # The plugin will automatically use the auto mounted token

--- a/app-config.yaml
+++ b/app-config.yaml
@@ -15,7 +15,7 @@ app:
         icon: chat
         links:
           - url: https://join.slack.com/t/operatefirst/shared_invite/zt-o2gn4wn8-O39g7sthTAuPCvaCNRnLww
-            title: '#support'
+            title: "#support"
 
 organization:
   name: Operate First Cloud
@@ -32,8 +32,8 @@ backend:
   # Content-Security-Policy directives follow the Helmet format: https://helmetjs.github.io/#reference
   # Default Helmet Content-Security-Policy values can be removed by setting the key to false
   csp:
-    connect-src: ["'self'", 'http:', 'https:']
-    img-src: ["'self'", 'https:']
+    connect-src: ["'self'", "http:", "https:"]
+    img-src: ["'self'", "https:"]
   cors:
     origin: http://localhost:7007
     methods: [GET, POST, PUT, DELETE]
@@ -46,11 +46,11 @@ backend:
     # workingDirectory: /tmp
   reading:
     allow:
-      - host: 'argocd.operate-first.cloud'
-      - host: 'raw.githubusercontent.com'
+      - host: "argocd.operate-first.cloud"
+      - host: "raw.githubusercontent.com"
 
 proxy:
-  '/argocd/api':
+  "/argocd/api":
     # url to the api of your hosted argoCD instance
     target: https://argocd.operate-first.cloud/api/v1/
     changeOrigin: true
@@ -59,7 +59,7 @@ proxy:
     headers:
       Cookie:
         $env: ARGOCD_AUTH_TOKEN
-  '/grafana/api':
+  "/grafana/api":
     target: https://grafana.operate-first.cloud
     headers:
       Authorization: Bearer ${GRAFANA_TOKEN}
@@ -70,13 +70,14 @@ grafana:
 
 # Reference documentation http://backstage.io/docs/features/techdocs/configuration
 techdocs:
-  builder: 'local'
+  builder: "local"
   generator:
-    runIn: 'local'
+    runIn: "local"
   publisher:
-    type: 'local'
+    type: "local"
 
 catalog:
+  readonly: true
   rules:
     - allow:
         - Component
@@ -87,17 +88,6 @@ catalog:
         - Domain
         - Api
         - Resource
-  locations:
-    - type: url
-      target: https://github.com/operate-first/apps/blob/master/service-catalog/all.yaml
 
 permission:
   enabled: true
-
-auth:
-  environment: development
-  providers:
-    github:
-      development:
-        clientId: ${AUTH_GITHUB_CLIENT_ID}
-        clientSecret: ${AUTH_GITHUB_CLIENT_SECRET}

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -72,6 +72,10 @@ Configurations for the cluster dev setup are in `app-config.dev.yaml`.
     {oc,kubectl} apply -k manifests/overlays/dev
     ```
 
+### Local GitHub integration
+
+If you want to gain access to GitHub content in development setup, please create a GitHub OAuth application [as described here](https://roadie.io/blog/github-auth-backstage/) and update your `.env` file accordingly.
+
 ### S2I image
 
 This repository uses s2i to create images. To create image run script located in `packages/backend`:


### PR DESCRIPTION
Simplify the local dev setup a tiny bit:

- Make Dev github auth setting available at local deployment only
- Fetch remote catalog in prod only
- Add env variable for relative local import of catalog files

/cc @SamoKopecky 