### PR TITLE
fix: Use .metadata.title on Home page when available

### DIFF
--- a/packages/app/src/components/home/HomePage.tsx
+++ b/packages/app/src/components/home/HomePage.tsx
@@ -120,14 +120,14 @@ const CatalogCards = () => {
                 e.metadata.annotations?.[ICON_ANNOTATION] ? (
                   <img
                     src={e.metadata.annotations[ICON_ANNOTATION]}
-                    alt={`${e.metadata.name} logo`}
+                    alt={`${e.metadata.title || e.metadata.name} logo`}
                   />
                 ) : (
                   <HelpIcon />
                 )
               }
               subheader={
-                <div className={classes.subheader}>{e.metadata.name}</div>
+                <div className={classes.subheader}>{e.metadata.title || e.metadata.name}</div>
               }
             >
               <Typography paragraph>{e.metadata.description}</Typography>


### PR DESCRIPTION
Since we're about to start using `.metadata.title`, it only make sense to use this display name on the HomePage as well.. EntityPage uses it by default.

/cc @SamoKopecky 