### PR TITLE
feat: Create cluster status backend plugin

### DIFF
--- a/.s2iignore
+++ b/.s2iignore
@@ -1,7 +1,7 @@
 .git
 node_modules
 packages/*/node_modules
-plugins
+plugins/*/node_modules
 manifests
 dist-types
 .aicoe-ci.yaml

--- a/app-config.dev.yaml
+++ b/app-config.dev.yaml
@@ -43,3 +43,6 @@ kubernetes:
           # Optional values
           # dashboardUrl: <dashboard_url>
           # dashboardApp: <dashboard_type>  # Supported dashboards: standard, rancher, openshift, gke, aks, eks
+
+clusterStatus:
+  acmCluster: 'dev-cluster'

--- a/app-config.local.yaml
+++ b/app-config.local.yaml
@@ -46,3 +46,6 @@ kubernetes:
           # Optional values
           # dashboardUrl: <dashboard_url>
           # dashboardApp: <dashboard_type>  # Supported dashboards: standard, rancher, openshift, gke, aks, eks
+
+clusterStatus:
+  acmCluster: 'dev-cluster'

--- a/app-config.prod.yaml
+++ b/app-config.prod.yaml
@@ -63,8 +63,6 @@ kubernetes:
           serviceAccountToken: ${moc_smaug_token}
           dashboardUrl: https://console-openshift-console.apps.smaug.na.operate-first.cloud
           dashboardApp: openshift
-    - type: 'config'
-      clusters:
         - url: https://api.moc-infra.massopen.cloud:6443
           name: infra
           authProvider: 'serviceAccount'
@@ -73,8 +71,6 @@ kubernetes:
           serviceAccountToken: ${moc_infra_token}
           dashboardUrl: https://console-openshift-console.apps.moc-infra.massopen.cloud
           dashboardApp: openshift
-    - type: 'config'
-      clusters:
         - url: https://api.curator.massopen.cloud:6443
           name: curator
           authProvider: 'serviceAccount'
@@ -83,8 +79,6 @@ kubernetes:
           serviceAccountToken: ${moc_curator_token}
           dashboardUrl: https://console-openshift-console.apps.curator.massopen.cloud
           dashboardApp: openshift
-    - type: 'config'
-      clusters:
         - url: https://api.balrog.aws.operate-first.cloud:6443
           name: balrog
           authProvider: 'serviceAccount'
@@ -93,8 +87,6 @@ kubernetes:
           serviceAccountToken: ${emea_balrog_token}
           dashboardUrl: https://console-openshift-console.apps.balrog.aws.operate-first.cloud
           dashboardApp: openshift
-    - type: 'config'
-      clusters:
         - url: https://api.odh-cl1.apps.os-climate.org:6443
           name: osc-cl1
           authProvider: 'serviceAccount'
@@ -103,8 +95,6 @@ kubernetes:
           serviceAccountToken: ${osc_osc-cl1_token}
           dashboardUrl: https://console-openshift-console.apps.odh-cl1.apps.os-climate.org
           dashboardApp: openshift
-    - type: 'config'
-      clusters:
         - url: https://api.odh-cl2.apps.os-climate.org:6443
           name: osc-cl2
           authProvider: 'serviceAccount'
@@ -113,3 +103,6 @@ kubernetes:
           serviceAccountToken: ${osc_osc-cl2_token}
           dashboardUrl: https://console-openshift-console.apps.odh-cl2.apps.os-climate.org
           dashboardApp: openshift
+
+clusterStatus:
+  acmCluster: 'infra'

--- a/manifests/components/rbac/role.yaml
+++ b/manifests/components/rbac/role.yaml
@@ -56,3 +56,11 @@ rules:
   - get
   - watch
   - list
+- apiGroups:
+  - cluster.open-cluster-management.io
+  resources:
+  - managedclusters
+  verbs:
+  - get
+  - watch
+  - list

--- a/packages/backend/src/index.ts
+++ b/packages/backend/src/index.ts
@@ -29,10 +29,11 @@ import proxy from './plugins/proxy';
 import techdocs from './plugins/techdocs';
 import search from './plugins/search';
 import permission from './plugins/permission';
-import { PluginEnvironment } from './types';
-import { ServerPermissionClient } from '@backstage/plugin-permission-node';
 import badges from './plugins/badges';
 import kubernetes from './plugins/kubernetes';
+import clusterStatus from './plugins/cluster-status';
+import { PluginEnvironment } from './types';
+import { ServerPermissionClient } from '@backstage/plugin-permission-node';
 
 function makeCreateEnv(config: Config) {
   const root = getRootLogger();
@@ -86,6 +87,7 @@ async function main() {
   const permissionEnv = useHotMemoize(module, () => createEnv('permission'));
   const badgesEnv = useHotMemoize(module, () => createEnv('badges'));
   const kubernetesEnv = useHotMemoize(module, () => createEnv('kubernetes'));
+  const clusterStatusEnv = useHotMemoize(module, () => createEnv('cluster-status'));
 
   const apiRouter = Router();
   apiRouter.use('/catalog', await catalog(catalogEnv));
@@ -97,6 +99,7 @@ async function main() {
   apiRouter.use('/permission', await permission(permissionEnv));
   apiRouter.use('/badges', await badges(badgesEnv));
   apiRouter.use('/kubernetes', await kubernetes(kubernetesEnv));
+  apiRouter.use('/cluster-status', await clusterStatus(clusterStatusEnv));
 
   // Add backends ABOVE this line; this 404 handler is the catch-all fallback
   apiRouter.use(notFoundHandler());

--- a/packages/backend/src/plugins/cluster-status.ts
+++ b/packages/backend/src/plugins/cluster-status.ts
@@ -1,0 +1,13 @@
+import { createRouter } from '@internal/plugin-cluster-status-backend';
+import { Router } from 'express';
+import { PluginEnvironment } from '../types';
+
+export default async function createPlugin(
+  env: PluginEnvironment,
+): Promise<Router> {
+
+  return await createRouter({
+    logger: env.logger,
+    config: env.config,
+  });
+}

--- a/plugins/cluster-status-backend/.eslintrc.js
+++ b/plugins/cluster-status-backend/.eslintrc.js
@@ -1,0 +1,1 @@
+module.exports = require('@backstage/cli/config/eslint-factory')(__dirname);

--- a/plugins/cluster-status-backend/README.md
+++ b/plugins/cluster-status-backend/README.md
@@ -1,0 +1,9 @@
+# cluster-status
+
+Welcome to the cluster-status backend plugin! This plugin serves as the backend for showing the status page of resources with `kind: cluster`.
+
+## Documentation
+
+More detailed documentation is located in the [`backstage` component documentation][1].
+
+[1]: https://service-catalog.operate-first.cloud/catalog/default/component/backstage/docs

--- a/plugins/cluster-status-backend/package.json
+++ b/plugins/cluster-status-backend/package.json
@@ -1,0 +1,46 @@
+{
+  "name": "@internal/plugin-cluster-status-backend",
+  "version": "0.1.0",
+  "main": "src/index.ts",
+  "types": "src/index.ts",
+  "license": "Apache-2.0",
+  "private": true,
+  "publishConfig": {
+    "access": "public",
+    "main": "dist/index.cjs.js",
+    "types": "dist/index.d.ts"
+  },
+  "backstage": {
+    "role": "backend-plugin"
+  },
+  "scripts": {
+    "start": "backstage-cli package start",
+    "build": "backstage-cli package build",
+    "lint": "backstage-cli package lint",
+    "test": "backstage-cli package test",
+    "clean": "backstage-cli package clean",
+    "prepack": "backstage-cli package prepack",
+    "postpack": "backstage-cli package postpack"
+  },
+  "configSchema": "schema.d.ts",
+  "dependencies": {
+    "@backstage/backend-common": "^0.13.3",
+    "@backstage/config": "^1.0.1",
+    "@kubernetes/client-node": "^0.17.1",
+    "@types/express": "*",
+    "express": "^4.17.1",
+    "express-promise-router": "^4.1.0",
+    "node-fetch": "^2.6.7",
+    "winston": "^3.2.1",
+    "yn": "^4.0.0"
+  },
+  "devDependencies": {
+    "@backstage/cli": "^0.17.1",
+    "@types/supertest": "^2.0.8",
+    "msw": "^0.35.0",
+    "supertest": "^4.0.2"
+  },
+  "files": [
+    "dist"
+  ]
+}

--- a/plugins/cluster-status-backend/schema.d.ts
+++ b/plugins/cluster-status-backend/schema.d.ts
@@ -1,0 +1,9 @@
+export interface Config {
+  clusterStatus: {
+    /**
+     * Name of the cluster where the ACM(Advanced Cluster Management) operator is installed
+     * @visiblity frontend
+     */
+    acmCluster: string;
+  }
+}

--- a/plugins/cluster-status-backend/src/index.ts
+++ b/plugins/cluster-status-backend/src/index.ts
@@ -1,0 +1,18 @@
+/*
+ * Copyright 2020 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export * from './service/router';
+export * from './types/types';

--- a/plugins/cluster-status-backend/src/run.ts
+++ b/plugins/cluster-status-backend/src/run.ts
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2020 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { getRootLogger } from '@backstage/backend-common';
+
+const logger = getRootLogger();
+
+process.on('SIGINT', () => {
+  logger.info('CTRL+C pressed; exiting.');
+  process.exit(0);
+});

--- a/plugins/cluster-status-backend/src/service/router.ts
+++ b/plugins/cluster-status-backend/src/service/router.ts
@@ -33,28 +33,27 @@ export async function createRouter(
   const { logger } = options;
   const { config } = options;
 
-  const unavaliableCluster: ClusterDetails = {
+  const unavailableCluster: ClusterDetails = {
     status: {
-      avaliable: false,
+      available: false,
       reason: 'ACM cluster unreachable'
     }
   }
 
-  const statusCheck = new StatusCheck(config, logger)
+  const statusCheck = new StatusCheck(config, logger);
 
   const router = Router();
   router.use(express.json());
 
-  router.get('/status/:clusterName', (request, response) => {
-    const clusterName = request.params.clusterName
+  router.get('/status/:clusterName', ({ params: { clusterName }}, response) => {
     logger.info(`Incoming status request for ${clusterName} cluster`)
     statusCheck.getClusterStatus(clusterName)
       .then((resp) => {
         response.send(statusCheck.parseStatusCheck(resp.body))
       })
       .catch((resp) => {
-        logger.warn(resp)
-        response.send(unavaliableCluster);
+        logger.warn(resp);
+        response.send(unavailableCluster);
       })
   });
 
@@ -69,8 +68,8 @@ export async function createRouter(
         response.send(parsedClusters)
       })
       .catch((resp) => {
-        logger.warn(resp)
-        response.send([unavaliableCluster])
+        logger.warn(resp);
+        response.send([unavailableCluster]);
       })
   });
   router.use(errorHandler());

--- a/plugins/cluster-status-backend/src/service/router.ts
+++ b/plugins/cluster-status-backend/src/service/router.ts
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2020 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { errorHandler } from '@backstage/backend-common';
+import { Config } from '@backstage/config';
+import express from 'express';
+import Router from 'express-promise-router';
+import { Logger } from 'winston';
+import { StatusCheck } from '../statusCheck/StatusCheck';
+import { ClusterDetails } from '../types/types';
+
+export interface RouterOptions {
+  logger: Logger;
+  config: Config;
+}
+
+export async function createRouter(
+  options: RouterOptions,
+): Promise<express.Router> {
+  const { logger } = options;
+  const { config } = options;
+
+  const unavaliableCluster: ClusterDetails = {
+    status: {
+      avaliable: false,
+      reason: 'ACM cluster unreachable'
+    }
+  }
+
+  const statusCheck = new StatusCheck(config, logger)
+
+  const router = Router();
+  router.use(express.json());
+
+  router.get('/status/:clusterName', (request, response) => {
+    const clusterName = request.params.clusterName
+    logger.info(`Incoming status request for ${clusterName} cluster`)
+    statusCheck.getClusterStatus(clusterName)
+      .then((resp) => {
+        response.send(statusCheck.parseStatusCheck(resp.body))
+      })
+      .catch((resp) => {
+        logger.warn(resp)
+        response.send(unavaliableCluster);
+      })
+  });
+
+  router.get('/status', (_, response) => {
+    logger.info(`Incoming status request for all clusters`)
+    statusCheck.getAllClustersStatus()
+      .then((resp) => {
+        const parsedClusters: Array<ClusterDetails> = resp.body.items
+          .map((cluster: any) => (
+            statusCheck.parseStatusCheck(cluster)
+          ))
+        response.send(parsedClusters)
+      })
+      .catch((resp) => {
+        logger.warn(resp)
+        response.send([unavaliableCluster])
+      })
+  });
+  router.use(errorHandler());
+  return router;
+}

--- a/plugins/cluster-status-backend/src/setupTests.ts
+++ b/plugins/cluster-status-backend/src/setupTests.ts
@@ -1,0 +1,17 @@
+/*
+ * Copyright 2020 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export {};

--- a/plugins/cluster-status-backend/src/statusCheck/StatusCheck.ts
+++ b/plugins/cluster-status-backend/src/statusCheck/StatusCheck.ts
@@ -1,0 +1,132 @@
+import { Config } from "@backstage/config";
+import { ClusterDetails } from "../types/types";
+import { CustomObjectsApi } from "@kubernetes/client-node"
+import { Logger } from 'winston';
+import { getCustomObjectsApi } from "./kubernetesApi";
+
+export class StatusCheck {
+  acmCluster: string;
+  logger: Logger
+  config: Config
+  api: CustomObjectsApi
+
+
+  constructor(config: Config, logger: Logger) {
+    this.logger = logger
+    this.config = config
+    this.acmCluster = this.config.getString('clusterStatus.acmCluster')
+    this.api = getCustomObjectsApi(this.getAcmClusterFromConfig(), this.logger)
+  }
+
+  public getAllClustersStatus = (): Promise<any> => (
+    // Empty string means get all clusters
+    this.getManagedClusterViaApi('')
+  )
+
+  public getClusterStatus = (clusterName: string): Promise<any> => {
+    this.checkClusterNames(clusterName);
+
+    let fixedClusterName = clusterName
+    if (clusterName === this.acmCluster) {
+      fixedClusterName = 'local-cluster'
+    }
+
+    return this.getManagedClusterViaApi(fixedClusterName);
+  }
+
+  public parseStatusCheck = (managedCluster: any): ClusterDetails => {
+    const clusterStatus: any = managedCluster.status
+    const avaliable = clusterStatus.conditions.find(
+      (value: any) => (value.type === 'ManagedClusterConditionAvailable')
+    ).status.toLowerCase() === 'true' ? true : false
+
+    const defaultStatus: ClusterDetails = {
+      name: managedCluster.metadata.name,
+      status: {
+        avaliable: avaliable,
+        reason: 'Cluster is up'
+      }
+    }
+
+    if (!avaliable) {
+      defaultStatus.status.reason = 'Cluster is down'
+      return defaultStatus;
+    }
+
+    const clusterClaims = clusterStatus.clusterClaims
+    const allocatable = clusterStatus.allocatable
+    const capacity = clusterStatus.capacity
+    const parsedClusterInfo = {
+      openshiftVersion: this.getClaim(clusterClaims, 'version.openshift.io'),
+      kubernetesVersion: this.getClaim(clusterClaims, 'kubeversion.open-cluster-management.io'),
+      platform: this.getClaim(clusterClaims, 'platform.open-cluster-management.io'),
+      region: this.getClaim(clusterClaims, 'region.open-cluster-management.io'),
+      allocatableResources: {
+        cpuCores: allocatable.cpu,
+        memorySize: allocatable.memory,
+        numberOfPods: allocatable.pods,
+      },
+      avaliableResources: {
+        cpuCores: capacity.cpu,
+        memorySize: capacity.memory,
+        numberOfPods: capacity.pods,
+      }
+    }
+
+    return {
+      ...defaultStatus,
+      ...parsedClusterInfo
+    }
+  }
+
+  private getManagedClusterViaApi = (clusterName: string): Promise<any> => (
+    this.api.getClusterCustomObject(
+      'cluster.open-cluster-management.io',
+      'v1',
+      'managedclusters',
+      clusterName,
+    )
+  )
+
+  private getClaim = (clusterClaims: any[], claimName: string): string => (
+    clusterClaims.find((value: any) => value.name === claimName).value
+  )
+
+  private getAcmClusterFromConfig = (): Config => {
+    const clusters = this.getClustersFromConfig();
+
+    const filteredClusters = clusters.filter((value) => (
+      value.getString('name') === this.acmCluster
+    ));
+    if (filteredClusters.length !== 1) {
+      this.logger.error(`found number of ACM clusters (${filteredClusters.length}) other then 1`)
+      throw new Error()
+    }
+    return filteredClusters[0];
+  }
+
+  private checkClusterNames = (clusterName: string) => {
+    const clusters = this.getClustersFromConfig();
+    if (clusters.some((value) => (
+      value.getString('name') !== clusterName
+    ))) {
+      throw new Error(`${clusterName} cluster is not contained in the config file`)
+    }
+  }
+
+  private getClustersFromConfig = (): Config[] => {
+    const clusters = this.config.getConfigArray('kubernetes.clusterLocatorMethods')
+      .map((value) => {
+        const configType = value.getString('type')
+        if (configType !== 'config') {
+          this.logger.warn(`${configType} is not a supported configuration type`)
+          return [];
+        }
+        return value.getConfigArray('clusters');
+      }).flat(1);
+    return clusters;
+  }
+
+  // TODO: This doesn't work if the clusters have more then one ACM cluster
+
+}

--- a/plugins/cluster-status-backend/src/statusCheck/StatusCheck.ts
+++ b/plugins/cluster-status-backend/src/statusCheck/StatusCheck.ts
@@ -6,16 +6,16 @@ import { getCustomObjectsApi } from "./kubernetesApi";
 
 export class StatusCheck {
   acmCluster: string;
-  logger: Logger
-  config: Config
-  api: CustomObjectsApi
+  logger: Logger;
+  config: Config;
+  api: CustomObjectsApi;
 
 
   constructor(config: Config, logger: Logger) {
-    this.logger = logger
-    this.config = config
-    this.acmCluster = this.config.getString('clusterStatus.acmCluster')
-    this.api = getCustomObjectsApi(this.getAcmClusterFromConfig(), this.logger)
+    this.logger = logger;
+    this.config = config;
+    this.acmCluster = this.config.getString('clusterStatus.acmCluster');
+    this.api = getCustomObjectsApi(this.getAcmClusterFromConfig(), this.logger);
   }
 
   public getAllClustersStatus = (): Promise<any> => (
@@ -26,9 +26,9 @@ export class StatusCheck {
   public getClusterStatus = (clusterName: string): Promise<any> => {
     this.checkClusterNames(clusterName);
 
-    let fixedClusterName = clusterName
+    let fixedClusterName = clusterName;
     if (clusterName === this.acmCluster) {
-      fixedClusterName = 'local-cluster'
+      fixedClusterName = 'local-cluster';
     }
 
     return this.getManagedClusterViaApi(fixedClusterName);
@@ -36,29 +36,32 @@ export class StatusCheck {
 
   public parseStatusCheck = (managedCluster: any): ClusterDetails => {
     const clusterStatus: any = managedCluster.status
-    const avaliable = clusterStatus.conditions.find(
+    const available = clusterStatus.conditions.find(
       (value: any) => (value.type === 'ManagedClusterConditionAvailable')
-    ).status.toLowerCase() === 'true' ? true : false
+    ).status.toLowerCase() === 'true' ? true : false;
 
     const defaultStatus: ClusterDetails = {
       name: managedCluster.metadata.name,
       status: {
-        avaliable: avaliable,
-        reason: 'Cluster is up'
+        available: available,
+        reason: 'Cluster is up',
       }
     }
 
-    if (!avaliable) {
-      defaultStatus.status.reason = 'Cluster is down'
+    if (!available) {
+      defaultStatus.status.reason = 'Cluster is down';
       return defaultStatus;
     }
 
-    const clusterClaims = clusterStatus.clusterClaims
-    const allocatable = clusterStatus.allocatable
-    const capacity = clusterStatus.capacity
+    const clusterClaims = clusterStatus.clusterClaims;
+    const allocatable = clusterStatus.allocatable;
+    const capacity = clusterStatus.capacity;
     const parsedClusterInfo = {
-      openshiftVersion: this.getClaim(clusterClaims, 'version.openshift.io'),
+      consoleUrl: this.getClaim(clusterClaims, 'consoleurl.cluster.open-cluster-management.io',),
       kubernetesVersion: this.getClaim(clusterClaims, 'kubeversion.open-cluster-management.io'),
+      oauthUrl: this.getClaim(clusterClaims, 'oauthredirecturis.openshift.io'),
+      openshiftId: this.getClaim(clusterClaims, 'id.openshift.io'),
+      openshiftVersion: this.getClaim(clusterClaims, 'version.openshift.io'),
       platform: this.getClaim(clusterClaims, 'platform.open-cluster-management.io'),
       region: this.getClaim(clusterClaims, 'region.open-cluster-management.io'),
       allocatableResources: {
@@ -66,7 +69,7 @@ export class StatusCheck {
         memorySize: allocatable.memory,
         numberOfPods: allocatable.pods,
       },
-      avaliableResources: {
+      availableResources: {
         cpuCores: capacity.cpu,
         memorySize: capacity.memory,
         numberOfPods: capacity.pods,
@@ -75,7 +78,7 @@ export class StatusCheck {
 
     return {
       ...defaultStatus,
-      ...parsedClusterInfo
+      ...parsedClusterInfo,
     }
   }
 
@@ -99,8 +102,8 @@ export class StatusCheck {
       value.getString('name') === this.acmCluster
     ));
     if (filteredClusters.length !== 1) {
-      this.logger.error(`found number of ACM clusters (${filteredClusters.length}) other then 1`)
-      throw new Error()
+      this.logger.error(`found number of ACM clusters (${filteredClusters.length}) other than 1`);
+      throw new Error();
     }
     return filteredClusters[0];
   }
@@ -110,7 +113,7 @@ export class StatusCheck {
     if (clusters.some((value) => (
       value.getString('name') !== clusterName
     ))) {
-      throw new Error(`${clusterName} cluster is not contained in the config file`)
+      throw new Error(`${clusterName} cluster is not contained in the config file`);
     }
   }
 
@@ -119,7 +122,7 @@ export class StatusCheck {
       .map((value) => {
         const configType = value.getString('type')
         if (configType !== 'config') {
-          this.logger.warn(`${configType} is not a supported configuration type`)
+          this.logger.warn(`${configType} is not a supported configuration type`);
           return [];
         }
         return value.getConfigArray('clusters');

--- a/plugins/cluster-status-backend/src/statusCheck/kubernetesApi.ts
+++ b/plugins/cluster-status-backend/src/statusCheck/kubernetesApi.ts
@@ -3,16 +3,16 @@ import { CustomObjectsApi, KubeConfig } from "@kubernetes/client-node"
 import { Logger } from 'winston';
 
 export const getCustomObjectsApi = (clusterConfig: Config, logger: Logger): CustomObjectsApi => {
-  const clusterToken = clusterConfig.getOptionalString('serviceAccountToken')
+  const clusterToken = clusterConfig.getOptionalString('serviceAccountToken');
   const kubeConfig = new KubeConfig();
 
   if (!clusterToken) {
-    logger.info('Using default kubernetes config')
+    logger.info('Using default kubernetes config');
     kubeConfig.loadFromDefault();
-    return kubeConfig.makeApiClient(CustomObjectsApi)
+    return kubeConfig.makeApiClient(CustomObjectsApi);
   }
 
-  logger.info('Loading kubernetes config from config file')
+  logger.info('Loading kubernetes config from config file');
   const cluster = {
     name: clusterConfig.getString('name'),
     server: clusterConfig.getString('url'),
@@ -37,5 +37,5 @@ export const getCustomObjectsApi = (clusterConfig: Config, logger: Logger): Cust
     contexts: [context],
     currentContext: context.name,
   });
-  return kubeConfig.makeApiClient(CustomObjectsApi)
+  return kubeConfig.makeApiClient(CustomObjectsApi);
 }

--- a/plugins/cluster-status-backend/src/statusCheck/kubernetesApi.ts
+++ b/plugins/cluster-status-backend/src/statusCheck/kubernetesApi.ts
@@ -1,0 +1,41 @@
+import { Config } from "@backstage/config";
+import { CustomObjectsApi, KubeConfig } from "@kubernetes/client-node"
+import { Logger } from 'winston';
+
+export const getCustomObjectsApi = (clusterConfig: Config, logger: Logger): CustomObjectsApi => {
+  const clusterToken = clusterConfig.getOptionalString('serviceAccountToken')
+  const kubeConfig = new KubeConfig();
+
+  if (!clusterToken) {
+    logger.info('Using default kubernetes config')
+    kubeConfig.loadFromDefault();
+    return kubeConfig.makeApiClient(CustomObjectsApi)
+  }
+
+  logger.info('Loading kubernetes config from config file')
+  const cluster = {
+    name: clusterConfig.getString('name'),
+    server: clusterConfig.getString('url'),
+    skipTLSVerify: clusterConfig.getOptionalBoolean('skipTLSVerify') ?? false,
+    caData: clusterConfig.getOptionalString('caData'),
+  };
+
+  const user = {
+    name: 'backstage',
+    token: clusterToken,
+  };
+
+  const context = {
+    name: cluster.name,
+    user: user.name,
+    cluster: cluster.name,
+  };
+
+  kubeConfig.loadFromOptions({
+    clusters: [cluster],
+    users: [user],
+    contexts: [context],
+    currentContext: context.name,
+  });
+  return kubeConfig.makeApiClient(CustomObjectsApi)
+}

--- a/plugins/cluster-status-backend/src/types/types.ts
+++ b/plugins/cluster-status-backend/src/types/types.ts
@@ -1,0 +1,21 @@
+export interface ClusterDetails {
+  name?: string,
+  openshiftVersion?: string,
+  kubernetesVersion?: string,
+  platform?: string,
+  region?: string,
+  status: {
+    avaliable: boolean,
+    reason: string,
+  }
+  allocatableResources?: {
+    cpuCores: number,
+    memorySize: string,
+    numberOfPods: number,
+  }
+  avaliableResources?: {
+    cpuCores: number,
+    memorySize: string,
+    numberOfPods: number,
+  }
+}

--- a/plugins/cluster-status-backend/src/types/types.ts
+++ b/plugins/cluster-status-backend/src/types/types.ts
@@ -1,21 +1,24 @@
 export interface ClusterDetails {
-  name?: string,
-  openshiftVersion?: string,
+  consoleUrl?: string,
   kubernetesVersion?: string,
+  name?: string,
+  oauthUrl?: string
+  openshiftId?: string
+  openshiftVersion?: string,
   platform?: string,
   region?: string,
-  status: {
-    avaliable: boolean,
-    reason: string,
-  }
   allocatableResources?: {
     cpuCores: number,
     memorySize: string,
     numberOfPods: number,
   }
-  avaliableResources?: {
+  availableResources?: {
     cpuCores: number,
     memorySize: string,
     numberOfPods: number,
+  }
+  status: {
+    available: boolean,
+    reason: string,
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3607,6 +3607,28 @@
     underscore "^1.9.1"
     ws "^7.3.1"
 
+"@kubernetes/client-node@^0.17.1":
+  version "0.17.1"
+  resolved "https://registry.yarnpkg.com/@kubernetes/client-node/-/client-node-0.17.1.tgz#a5740712848d77823e7d0eee70229936398b4142"
+  integrity sha512-qXANjukuTq/drb1hq1NCYZafpdRTvbyTzbliWO6RwW7eEb2b9qwINbw0DiVHpBQg3e9DeQd8+brI1sR1Fck5kQ==
+  dependencies:
+    byline "^5.0.0"
+    execa "5.0.0"
+    isomorphic-ws "^4.0.1"
+    js-yaml "^4.1.0"
+    jsonpath-plus "^0.19.0"
+    request "^2.88.0"
+    rfc4648 "^1.3.0"
+    shelljs "^0.8.5"
+    stream-buffers "^3.0.2"
+    tar "^6.1.11"
+    tmp-promise "^3.0.2"
+    tslib "^1.9.3"
+    underscore "^1.9.1"
+    ws "^7.3.1"
+  optionalDependencies:
+    openid-client "^5.1.6"
+
 "@leichtgewicht/ip-codec@^2.0.1":
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/@leichtgewicht/ip-codec/-/ip-codec-2.0.4.tgz#b2ac626d6cb9c8718ab459166d4bb405b8ffa78b"
@@ -4458,6 +4480,26 @@
     prop-types "^15.7.2"
     react-is "^16.8.0 || ^17.0.0"
 
+"@mswjs/cookies@^0.1.6":
+  version "0.1.7"
+  resolved "https://registry.yarnpkg.com/@mswjs/cookies/-/cookies-0.1.7.tgz#d334081b2c51057a61c1dd7b76ca3cac02251651"
+  integrity sha512-bDg1ReMBx+PYDB4Pk7y1Q07Zz1iKIEUWQpkEXiA2lEWg9gvOZ8UBmGXilCEUvyYoRFlmr/9iXTRR69TrgSwX/Q==
+  dependencies:
+    "@types/set-cookie-parser" "^2.4.0"
+    set-cookie-parser "^2.4.6"
+
+"@mswjs/interceptors@^0.12.6":
+  version "0.12.7"
+  resolved "https://registry.yarnpkg.com/@mswjs/interceptors/-/interceptors-0.12.7.tgz#0d1cd4cd31a0f663e0455993951201faa09d0909"
+  integrity sha512-eGjZ3JRAt0Fzi5FgXiV/P3bJGj0NqsN7vBS0J0FO2AQRQ0jCKQS4lEFm4wvlSgKQNfeuc/Vz6d81VtU3Gkx/zg==
+  dependencies:
+    "@open-draft/until" "^1.0.3"
+    "@xmldom/xmldom" "^0.7.2"
+    debug "^4.3.2"
+    headers-utils "^3.0.2"
+    outvariant "^1.2.0"
+    strict-event-emitter "^0.2.0"
+
 "@n1ru4l/push-pull-async-iterable-iterator@^3.1.0":
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/@n1ru4l/push-pull-async-iterable-iterator/-/push-pull-async-iterable-iterator-3.2.0.tgz#c15791112db68dd9315d329d652b7e797f737655"
@@ -4816,6 +4858,11 @@
     "@octokit/webhooks-methods" "^2.0.0"
     "@octokit/webhooks-types" "5.6.0"
     aggregate-error "^3.1.0"
+
+"@open-draft/until@^1.0.3":
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/@open-draft/until/-/until-1.0.3.tgz#db9cc719191a62e7d9200f6e7bab21c5b848adca"
+  integrity sha512-Aq58f5HiWdyDlFffbbSjAlv596h/cOnt2DO1w3DOC7OJ5EHs0hd/nycJfiu9RJbT6Yk6F1knnRRXNSpxoIVZ9Q==
 
 "@openapi-contrib/openapi-schema-to-json-schema@^3.0.0":
   version "3.1.2"
@@ -5445,6 +5492,16 @@
   dependencies:
     "@types/node" "*"
 
+"@types/cookie@^0.4.1":
+  version "0.4.1"
+  resolved "https://registry.yarnpkg.com/@types/cookie/-/cookie-0.4.1.tgz#bfd02c1f2224567676c1545199f87c3a861d878d"
+  integrity sha512-XW/Aa8APYr6jSVVA1y/DEIZX0/GMKLEVekNG727R8cs56ahETkRAy/3DR7+fJyh7oUgGwNQaRfXCun0+KbWY7Q==
+
+"@types/cookiejar@*":
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/@types/cookiejar/-/cookiejar-2.1.2.tgz#66ad9331f63fe8a3d3d9d8c6e3906dd10f6446e8"
+  integrity sha512-t73xJJrvdTjXrn4jLS9VSGRbz0nUY3cl2DMGDU48lKl+HR9dbbjW2A9r3g40VA++mQpy6uuHg33gy7du2BKpog==
+
 "@types/cors@^2.8.6":
   version "2.8.12"
   resolved "https://registry.yarnpkg.com/@types/cors/-/cors-2.8.12.tgz#6b2c510a7ad7039e98e7b8d3d6598f4359e5c080"
@@ -5572,6 +5629,14 @@
   dependencies:
     "@types/node" "*"
 
+"@types/inquirer@^7.3.3":
+  version "7.3.3"
+  resolved "https://registry.yarnpkg.com/@types/inquirer/-/inquirer-7.3.3.tgz#92e6676efb67fa6925c69a2ee638f67a822952ac"
+  integrity sha512-HhxyLejTHMfohAuhRun4csWigAMjXTmRyiJTU1Y/I1xmggikFMkOUoMQRlFm+zQcPEGHSs3io/0FAmNZf8EymQ==
+  dependencies:
+    "@types/through" "*"
+    rxjs "^6.4.0"
+
 "@types/istanbul-lib-coverage@*", "@types/istanbul-lib-coverage@^2.0.0", "@types/istanbul-lib-coverage@^2.0.1":
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.4.tgz#8467d4b3c087805d63580480890791277ce35c44"
@@ -5616,6 +5681,11 @@
   version "2.2.7"
   resolved "https://registry.yarnpkg.com/@types/js-cookie/-/js-cookie-2.2.7.tgz#226a9e31680835a6188e887f3988e60c04d3f6a3"
   integrity sha512-aLkWa0C0vO5b4Sr798E26QgOkss68Un0bLjs7u9qxzPT5CG+8DuNTffWES58YzJs3hrVAOs1wonycqEBqNJubA==
+
+"@types/js-levenshtein@^1.1.0":
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/@types/js-levenshtein/-/js-levenshtein-1.1.1.tgz#ba05426a43f9e4e30b631941e0aa17bf0c890ed5"
+  integrity sha512-qC4bCqYGy1y/NP7dDVr7KJarn+PbX1nSpwA7JXdu0HxT3QYjO8MJ+cntENtHFVy2dRAyBV23OZ6MxsW1AM1L8g==
 
 "@types/js-yaml@^4.0.1":
   version "4.0.5"
@@ -5881,6 +5951,13 @@
     "@types/mime" "^1"
     "@types/node" "*"
 
+"@types/set-cookie-parser@^2.4.0":
+  version "2.4.2"
+  resolved "https://registry.yarnpkg.com/@types/set-cookie-parser/-/set-cookie-parser-2.4.2.tgz#b6a955219b54151bfebd4521170723df5e13caad"
+  integrity sha512-fBZgytwhYAUkj/jC/FAV4RQ5EerRup1YQsXQCh8rZfiHkc4UahC192oH0smGwsXol3cL3A5oETuAHeQHmhXM4w==
+  dependencies:
+    "@types/node" "*"
+
 "@types/sinonjs__fake-timers@^6.0.2":
   version "6.0.4"
   resolved "https://registry.yarnpkg.com/@types/sinonjs__fake-timers/-/sinonjs__fake-timers-6.0.4.tgz#0ecc1b9259b76598ef01942f547904ce61a6a77d"
@@ -5932,6 +6009,21 @@
   dependencies:
     "@types/react" "*"
 
+"@types/superagent@*":
+  version "4.1.15"
+  resolved "https://registry.yarnpkg.com/@types/superagent/-/superagent-4.1.15.tgz#63297de457eba5e2bc502a7609426c4cceab434a"
+  integrity sha512-mu/N4uvfDN2zVQQ5AYJI/g4qxn2bHB6521t1UuH09ShNWjebTqN0ZFuYK9uYjcgmI0dTQEs+Owi1EO6U0OkOZQ==
+  dependencies:
+    "@types/cookiejar" "*"
+    "@types/node" "*"
+
+"@types/supertest@^2.0.8":
+  version "2.0.12"
+  resolved "https://registry.yarnpkg.com/@types/supertest/-/supertest-2.0.12.tgz#ddb4a0568597c9aadff8dbec5b2e8fddbe8692fc"
+  integrity sha512-X3HPWTwXRerBZS7Mo1k6vMVR1Z6zmJcDVn5O/31whe0tnjE4te6ZJSJGq1RiqHPjzPdMTfjCFogDJmwng9xHaQ==
+  dependencies:
+    "@types/superagent" "*"
+
 "@types/tar@^4.0.3":
   version "4.0.5"
   resolved "https://registry.yarnpkg.com/@types/tar/-/tar-4.0.5.tgz#5f953f183e36a15c6ce3f336568f6051b7b183f3"
@@ -5946,6 +6038,13 @@
   integrity sha512-oKZe+Mf4ioWlMuzVBaXQ9WDnEm1+umLx0InILg+yvZVBBDmzV5KfZyLrCvadtWcx8+916jLmHafcmqqffl+iIw==
   dependencies:
     "@types/jest" "*"
+
+"@types/through@*":
+  version "0.0.30"
+  resolved "https://registry.yarnpkg.com/@types/through/-/through-0.0.30.tgz#e0e42ce77e897bd6aead6f6ea62aeb135b8a3895"
+  integrity sha512-FvnCJljyxhPM3gkRgWmxmDZyAQSiBQQWLI0A0VFL0K7W1oRUrPJSqNO0NvTnLkBcotdlp3lKvaT0JrnyRDkzOg==
+  dependencies:
+    "@types/node" "*"
 
 "@types/tough-cookie@*":
   version "4.0.2"
@@ -6238,7 +6337,7 @@
     "@webassemblyjs/ast" "1.11.1"
     "@xtuc/long" "4.2.2"
 
-"@xmldom/xmldom@^0.7.0", "@xmldom/xmldom@^0.7.5":
+"@xmldom/xmldom@^0.7.0", "@xmldom/xmldom@^0.7.2", "@xmldom/xmldom@^0.7.5":
   version "0.7.5"
   resolved "https://registry.yarnpkg.com/@xmldom/xmldom/-/xmldom-0.7.5.tgz#09fa51e356d07d0be200642b0e4f91d8e6dd408d"
   integrity sha512-V3BIhmY36fXZ1OtVcI9W+FxQqxVLsPKcNjWigIaa81dLC9IolJl5Mt4Cvhmr0flUnjSpTdrbMTSbXqYqV5dT6A==
@@ -7951,6 +8050,11 @@ compare-func@^2.0.0:
     array-ify "^1.0.0"
     dot-prop "^5.1.0"
 
+component-emitter@^1.2.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/component-emitter/-/component-emitter-1.3.0.tgz#16e4070fba8ae29b679f2215853ee181ab2eabc0"
+  integrity sha512-Rd3se6QB+sO1TwqZjscQrurpEPIfO0/yYnSin6Q/rD3mOutHvUrCAhJub3r90uNb+SESBuE0QYoB90YdfatsRg==
+
 compress-brotli@^1.3.8:
   version "1.3.8"
   resolved "https://registry.yarnpkg.com/compress-brotli/-/compress-brotli-1.3.8.tgz#0c0a60c97a989145314ec381e84e26682e7b38db"
@@ -8203,7 +8307,7 @@ cookie@0.4.1:
   resolved "https://registry.yarnpkg.com/cookie/-/cookie-0.4.1.tgz#afd713fe26ebd21ba95ceb61f9a8116e50a537d1"
   integrity sha512-ZwrFkGJxUR3EIoXtO+yVE69Eb7KlixbaeAWfBQB9vVsNn/o+Yw69gBWSSDK825hQNdN+wF8zELf3dFNl/kxkUA==
 
-cookie@0.4.2:
+cookie@0.4.2, cookie@^0.4.1:
   version "0.4.2"
   resolved "https://registry.yarnpkg.com/cookie/-/cookie-0.4.2.tgz#0e41f24de5ecf317947c82fc789e06a884824432"
   integrity sha512-aSWTXFzaKWkvHO1Ny/s+ePFpvKsPnjc551iI41v3ny/ow6tBG5Vd+FuqGNhh1LxOmVzOlGUriIlOaokOvhaStA==
@@ -8212,6 +8316,11 @@ cookie@0.5.0, cookie@~0.5.0:
   version "0.5.0"
   resolved "https://registry.yarnpkg.com/cookie/-/cookie-0.5.0.tgz#d1f5d71adec6558c58f389987c366aa47e994f8b"
   integrity sha512-YZ3GUyn/o8gfKJlnlX7g7xq4gyO6OSuhGPKaaGssGB2qgDUS0gPgtTvoyZLTt9Ab6dC4hfc9dV5arkvc/OCmrw==
+
+cookiejar@^2.1.0:
+  version "2.1.3"
+  resolved "https://registry.yarnpkg.com/cookiejar/-/cookiejar-2.1.3.tgz#fc7a6216e408e74414b90230050842dacda75acc"
+  integrity sha512-JxbCBUdrfr6AQjOXrxoTvAMJO4HBTUIlBzslcJPAz+/KT8yk53fXun51u+RenNYvad/+Vc2DIz5o9UxlCDymFQ==
 
 copy-to-clipboard@^3, copy-to-clipboard@^3.2.0, copy-to-clipboard@^3.3.1:
   version "3.3.1"
@@ -9925,7 +10034,7 @@ events@1.1.1:
   resolved "https://registry.yarnpkg.com/events/-/events-1.1.1.tgz#9ebdb7635ad099c70dcc4c2a1f5004288e8bd924"
   integrity sha512-kEcvvCBByWXGnZy6JUlgAp2gBIUjfCAV6P6TgT1/aaQKcmuAEC4OZTV1I4EWQLz2gxZw76atuVyvHhTxvi0Flw==
 
-events@^3.0.0, events@^3.2.0:
+events@^3.0.0, events@^3.2.0, events@^3.3.0:
   version "3.3.0"
   resolved "https://registry.yarnpkg.com/events/-/events-3.3.0.tgz#31a95ad0a924e2d2c419a813aeb2c4e878ea7400"
   integrity sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==
@@ -10380,7 +10489,7 @@ form-data-encoder@^1.4.3:
   resolved "https://registry.yarnpkg.com/form-data-encoder/-/form-data-encoder-1.7.2.tgz#1f1ae3dccf58ed4690b86d87e4f57c654fbab040"
   integrity sha512-qfqtYan3rxrnCk1VYaA4H+Ms9xdpPqvLZa6xmMgFvhO32x7/3J/ExcTd6qpxM0vH2GdMI+poehyBZvqfMTto8A==
 
-form-data@^2.3.2, form-data@^2.5.0:
+form-data@^2.3.1, form-data@^2.3.2, form-data@^2.5.0:
   version "2.5.1"
   resolved "https://registry.yarnpkg.com/form-data/-/form-data-2.5.1.tgz#f2cbec57b5e59e23716e128fe44d4e5dd23895f4"
   integrity sha512-m21N3WOmEEURgk6B9GLOE4RuWOFf28Lhh9qGYeNlGq4VDXUlJy2th2slBNU8Gp8EzloYZOibZJ7t5ecIrFSjVA==
@@ -10428,6 +10537,11 @@ formdata-node@^4.0.0:
   dependencies:
     node-domexception "1.0.0"
     web-streams-polyfill "4.0.0-beta.1"
+
+formidable@^1.2.0:
+  version "1.2.6"
+  resolved "https://registry.yarnpkg.com/formidable/-/formidable-1.2.6.tgz#d2a51d60162bbc9b4a055d8457a7c75315d1a168"
+  integrity sha512-KcpbcpuLNOwrEjnbpMC0gS+X8ciDoZE1kkqzat4a8vrprf+s9pKNQ/QIwWfbfs4ltgmFl3MD177SNTkve3BwGQ==
 
 forwarded@0.2.0:
   version "0.2.0"
@@ -11062,6 +11176,11 @@ graphql-ws@^5.4.1:
   resolved "https://registry.yarnpkg.com/graphql-ws/-/graphql-ws-5.8.2.tgz#800184b1addb20b3010dc06cb70877703a5fff20"
   integrity sha512-hYo8kTGzxePFJtMGC7Y4cbypwifMphIJJ7n4TDcVUAfviRwQBnmZAbfZlC+XFwWDUaR7raEDQPxWctpccmE0JQ==
 
+graphql@^15.5.1:
+  version "15.8.0"
+  resolved "https://registry.yarnpkg.com/graphql/-/graphql-15.8.0.tgz#33410e96b012fa3bdb1091cc99a94769db212b38"
+  integrity sha512-5gghUc24tP9HRznNpV2+FIoq3xKkj5dTQqf4v0CpdPbFVwFkWoxOM+o+2OC9ZSvjEMTjfmG9QT+gcvggTwW1zw==
+
 graphql@^16.0.0:
   version "16.5.0"
   resolved "https://registry.yarnpkg.com/graphql/-/graphql-16.5.0.tgz#41b5c1182eaac7f3d47164fb247f61e4dfb69c85"
@@ -11225,6 +11344,11 @@ he@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/he/-/he-1.2.0.tgz#84ae65fa7eafb165fddb61566ae14baf05664f0f"
   integrity sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==
+
+headers-utils@^3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/headers-utils/-/headers-utils-3.0.2.tgz#dfc65feae4b0e34357308aefbcafa99c895e59ef"
+  integrity sha512-xAxZkM1dRyGV2Ou5bzMxBPNLoRCjcX+ya7KSWybQD2KwLphxsapUVK6x/02o7f4VU6GPSXch9vNY2+gkU8tYWQ==
 
 helmet@^5.0.2:
   version "5.1.0"
@@ -11679,7 +11803,7 @@ inquirer@^7.3.3:
     strip-ansi "^6.0.0"
     through "^2.3.6"
 
-inquirer@^8.2.0:
+inquirer@^8.1.1, inquirer@^8.2.0:
   version "8.2.4"
   resolved "https://registry.yarnpkg.com/inquirer/-/inquirer-8.2.4.tgz#ddbfe86ca2f67649a67daa6f1051c128f684f0b4"
   integrity sha512-nn4F01dxU8VeKfq192IjLsxu0/OmMZ4Lg3xKAns148rCaXP6ntAoEkVYZThWjwON8AlzdZZi6oqnhNbxUG9hVg==
@@ -11962,6 +12086,11 @@ is-negative-zero@^2.0.2:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/is-negative-zero/-/is-negative-zero-2.0.2.tgz#7bf6f03a28003b8b3965de3ac26f664d765f3150"
   integrity sha512-dqJvarLawXsFbNDeJW7zAz8ItJ9cd28YufuuFzh0G8pNHjJMnY08Dv7sYX2uF5UpQOwieAeOExEYAWWfu7ZZUA==
+
+is-node-process@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/is-node-process/-/is-node-process-1.0.1.tgz#4fc7ac3a91e8aac58175fe0578abbc56f2831b23"
+  integrity sha512-5IcdXuf++TTNt3oGl9EBdkvndXA8gmc4bz/Y+mdEpWh3Mcn/+kOw6hI7LD5CocqJWMzeb0I0ClndRVNdEPuJXQ==
 
 is-number-object@^1.0.4:
   version "1.0.7"
@@ -12733,6 +12862,11 @@ js-file-download@^0.4.12:
   version "0.4.12"
   resolved "https://registry.yarnpkg.com/js-file-download/-/js-file-download-0.4.12.tgz#10c70ef362559a5b23cdbdc3bd6f399c3d91d821"
   integrity sha512-rML+NkoD08p5Dllpjo0ffy4jRHeY6Zsapvr/W86N7E0yuzAO6qa5X9+xog6zQNlH102J7IXljNY2FtS6Lj3ucg==
+
+js-levenshtein@^1.1.6:
+  version "1.1.6"
+  resolved "https://registry.yarnpkg.com/js-levenshtein/-/js-levenshtein-1.1.6.tgz#c6cee58eb3550372df8deb85fad5ce66ce01d59d"
+  integrity sha512-X2BB11YZtrRqY4EnQcLX5Rh373zbK4alC1FW7D7MBhL2gtcC17cTnr6DmfHZeS0s2rTHjUTMMHfG7gO8SSdw+g==
 
 "js-tokens@^3.0.0 || ^4.0.0", js-tokens@^4.0.0:
   version "4.0.0"
@@ -13942,7 +14076,7 @@ meros@^1.1.4:
   resolved "https://registry.yarnpkg.com/meros/-/meros-1.2.0.tgz#096cdede2eb0b1610b219b1031b935260de1ad08"
   integrity sha512-3QRZIS707pZQnijHdhbttXRWwrHhZJ/gzolneoxKVz9N/xmsvY/7Ls8lpnI9gxbgxjcHsAVEW3mgwiZCo6kkJQ==
 
-methods@^1.0.0, methods@~1.1.2:
+methods@^1.0.0, methods@^1.1.1, methods@^1.1.2, methods@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/methods/-/methods-1.1.2.tgz#5529a4d67654134edcc5266656835b0f851afcee"
   integrity sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w==
@@ -14250,7 +14384,7 @@ mime-types@^2.0.8, mime-types@^2.1.12, mime-types@^2.1.27, mime-types@^2.1.31, m
   dependencies:
     mime-db "1.52.0"
 
-mime@1.6.0:
+mime@1.6.0, mime@^1.4.1:
   version "1.6.0"
   resolved "https://registry.yarnpkg.com/mime/-/mime-1.6.0.tgz#32cd9e5c64553bd58d19a568af452acff04981b1"
   integrity sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==
@@ -14507,6 +14641,32 @@ ms@2.1.3, ms@^2.0.0, ms@^2.1.1:
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.3.tgz#574c8138ce1d2b5861f0b44579dbadd60c6615b2"
   integrity sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==
 
+msw@^0.35.0:
+  version "0.35.0"
+  resolved "https://registry.yarnpkg.com/msw/-/msw-0.35.0.tgz#18a4ceb6c822ef226a30421d434413bc45030d38"
+  integrity sha512-V7A6PqaS31F1k//fPS0OnO7vllfaqBUFsMEu3IpYixyWpiUInfyglodnbXhhtDyytkQikpkPZv8TZi/CvZzv/w==
+  dependencies:
+    "@mswjs/cookies" "^0.1.6"
+    "@mswjs/interceptors" "^0.12.6"
+    "@open-draft/until" "^1.0.3"
+    "@types/cookie" "^0.4.1"
+    "@types/inquirer" "^7.3.3"
+    "@types/js-levenshtein" "^1.1.0"
+    chalk "^4.1.1"
+    chokidar "^3.4.2"
+    cookie "^0.4.1"
+    graphql "^15.5.1"
+    headers-utils "^3.0.2"
+    inquirer "^8.1.1"
+    is-node-process "^1.0.1"
+    js-levenshtein "^1.1.6"
+    node-fetch "^2.6.1"
+    node-match-path "^0.6.3"
+    statuses "^2.0.0"
+    strict-event-emitter "^0.2.0"
+    type-fest "^1.2.2"
+    yargs "^17.0.1"
+
 multicast-dns@^7.2.4:
   version "7.2.5"
   resolved "https://registry.yarnpkg.com/multicast-dns/-/multicast-dns-7.2.5.tgz#77eb46057f4d7adbd16d9290fa7299f6fa64cced"
@@ -14699,6 +14859,11 @@ node-libs-browser@^2.2.1:
     url "^0.11.0"
     util "^0.11.0"
     vm-browserify "^1.0.1"
+
+node-match-path@^0.6.3:
+  version "0.6.3"
+  resolved "https://registry.yarnpkg.com/node-match-path/-/node-match-path-0.6.3.tgz#55dd8443d547f066937a0752dce462ea7dc27551"
+  integrity sha512-fB1reOHKLRZCJMAka28hIxCwQLxGmd7WewOCBDYKpyA1KXi68A7vaGgdZAPhY2E6SXoYt3KqYCCvXLJ+O0Fu/Q==
 
 node-releases@^2.0.3:
   version "2.0.5"
@@ -15105,6 +15270,16 @@ openid-client@^5.1.3:
     object-hash "^2.0.1"
     oidc-token-hash "^5.0.1"
 
+openid-client@^5.1.6:
+  version "5.1.9"
+  resolved "https://registry.yarnpkg.com/openid-client/-/openid-client-5.1.9.tgz#6887e75ad3fa8d0c78d0ed693a5ea107d39b54de"
+  integrity sha512-o/11Xos2fRPpK1zQrPfSIhIusFrAkqGSPwkD0UlUB+CCuRzd7zrrBJwIjgnVv3VUSif9ZGXh2d3GSJNH2Koh5g==
+  dependencies:
+    jose "^4.1.4"
+    lru-cache "^6.0.0"
+    object-hash "^2.0.1"
+    oidc-token-hash "^5.0.1"
+
 optionator@^0.8.1:
   version "0.8.3"
   resolved "https://registry.yarnpkg.com/optionator/-/optionator-0.8.3.tgz#84fa1d036fe9d3c7e21d99884b601167ec8fb495"
@@ -15171,6 +15346,11 @@ ospath@^1.2.2:
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/ospath/-/ospath-1.2.2.tgz#1276639774a3f8ef2572f7fe4280e0ea4550c07b"
   integrity sha512-o6E5qJV5zkAbIDNhGSIlyOhScKXgQrSRMilfph0clDfM0nEnBOlKlH4sWDmG95BW/CvwNz0vmm7dJVtU2KlMiA==
+
+outvariant@^1.2.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/outvariant/-/outvariant-1.3.0.tgz#c39723b1d2cba729c930b74bf962317a81b9b1c9"
+  integrity sha512-yeWM9k6UPfG/nzxdaPlJkB2p08hCg4xP6Lx99F+vP8YF7xyZVfTmJjrrNalkmzudD4WFvNLVudQikqUmF8zhVQ==
 
 p-cancelable@^2.0.0:
   version "2.1.1"
@@ -16345,6 +16525,13 @@ qs@6.10.3, qs@^6.10.1, qs@^6.10.2, qs@^6.9.1, qs@^6.9.4:
   dependencies:
     side-channel "^1.0.4"
 
+qs@^6.5.1:
+  version "6.11.0"
+  resolved "https://registry.yarnpkg.com/qs/-/qs-6.11.0.tgz#fd0d963446f7a65e1367e01abd85429453f0c37a"
+  integrity sha512-MvjoMCJwEarSbUYk5O+nmoSzSutSsTwF85zcHPQ9OrlFoZOYIjaqBAJIqIXjptyD5vThxGq52Xu/MaJzRkIk4Q==
+  dependencies:
+    side-channel "^1.0.4"
+
 qs@~6.5.2:
   version "6.5.3"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.5.3.tgz#3aeeffc91967ef6e35c0e488ef46fb296ab76aad"
@@ -16935,7 +17122,7 @@ readable-stream@3, readable-stream@^3.0.0, readable-stream@^3.0.2, readable-stre
     string_decoder "^1.1.1"
     util-deprecate "^1.0.1"
 
-readable-stream@^2.0.0, readable-stream@^2.0.1, readable-stream@^2.0.2, readable-stream@^2.0.5, readable-stream@^2.0.6, readable-stream@^2.3.3, readable-stream@^2.3.6, readable-stream@~2.3.6:
+readable-stream@^2.0.0, readable-stream@^2.0.1, readable-stream@^2.0.2, readable-stream@^2.0.5, readable-stream@^2.0.6, readable-stream@^2.3.3, readable-stream@^2.3.5, readable-stream@^2.3.6, readable-stream@~2.3.6:
   version "2.3.7"
   resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.3.7.tgz#1eca1cf711aef814c04f62252a36a62f6cb23b57"
   integrity sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==
@@ -17470,7 +17657,7 @@ run-script-webpack-plugin@^0.0.11:
   resolved "https://registry.yarnpkg.com/run-script-webpack-plugin/-/run-script-webpack-plugin-0.0.11.tgz#04c510bed06b907fa2285e75feece71a25691171"
   integrity sha512-QmuBhiqBPmhQLpO5vMBHVTAGyoPBnrCM5gQ3IzgieiImBXiBbXcIv4kysCT1gilFNFxQk22oKQfiIhWbT/zXCw==
 
-rxjs@^6.6.0, rxjs@^6.6.3:
+rxjs@^6.4.0, rxjs@^6.6.0, rxjs@^6.6.3:
   version "6.6.7"
   resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-6.6.7.tgz#90ac018acabf491bf65044235d5863c4dab804c9"
   integrity sha512-hTdwr+7yYNIT5n4AMYp85KA6yw2Va0FLa3Rguvbpa4W3I5xynaBZo41cM3XM+4Q6fRMj3sBYIR1VAmZMXYJvRQ==
@@ -17688,6 +17875,11 @@ set-blocking@~2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/set-blocking/-/set-blocking-2.0.0.tgz#045f9782d011ae9a6803ddd382b24392b3d890f7"
   integrity sha1-BF+XgtARrppoA93TgrJDkrPYkPc=
+
+set-cookie-parser@^2.4.6:
+  version "2.5.1"
+  resolved "https://registry.yarnpkg.com/set-cookie-parser/-/set-cookie-parser-2.5.1.tgz#ddd3e9a566b0e8e0862aca974a6ac0e01349430b"
+  integrity sha512-1jeBGaKNGdEq4FgIrORu/N570dwoPYio8lSoYLWmX7sQ//0JY08Xh9o5pBcgmHQ/MbsYp/aZnOe1s1lIsbLprQ==
 
 set-harmonic-interval@^1.0.1:
   version "1.0.1"
@@ -18151,7 +18343,7 @@ start-server-and-test@^1.10.11:
     ps-tree "1.2.0"
     wait-on "6.0.0"
 
-statuses@2.0.1:
+statuses@2.0.1, statuses@^2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/statuses/-/statuses-2.0.1.tgz#55cb000ccf1d48728bd23c685a063998cf1a1b63"
   integrity sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==
@@ -18208,6 +18400,13 @@ stream-shift@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/stream-shift/-/stream-shift-1.0.1.tgz#d7088281559ab2778424279b0877da3c392d5a3d"
   integrity sha512-AiisoFqQ0vbGcZgQPY1cdP2I76glaVA/RauYR4G4thNFgkTqr90yXTo4LYX60Jl+sIlPNHHdGSwo01AvbKUSVQ==
+
+strict-event-emitter@^0.2.0:
+  version "0.2.4"
+  resolved "https://registry.yarnpkg.com/strict-event-emitter/-/strict-event-emitter-0.2.4.tgz#365714f0c95f059db31064ca745d5b33e5b30f6e"
+  integrity sha512-xIqTLS5azUH1djSUsLH9DbP6UnM/nI18vu8d43JigCQEoVsnY+mrlE+qv6kYqs6/1OkMnMIiL6ffedQSZStuoQ==
+  dependencies:
+    events "^3.3.0"
 
 strict-uri-encode@^2.0.0:
   version "2.0.0"
@@ -18412,6 +18611,30 @@ sucrase@^3.18.0, sucrase@^3.20.2:
     mz "^2.7.0"
     pirates "^4.0.1"
     ts-interface-checker "^0.1.9"
+
+superagent@^3.8.3:
+  version "3.8.3"
+  resolved "https://registry.yarnpkg.com/superagent/-/superagent-3.8.3.tgz#460ea0dbdb7d5b11bc4f78deba565f86a178e128"
+  integrity sha512-GLQtLMCoEIK4eDv6OGtkOoSMt3D+oq0y3dsxMuYuDvaNUvuT8eFBuLmfR0iYYzHC1e8hpzC6ZsxbuP6DIalMFA==
+  dependencies:
+    component-emitter "^1.2.0"
+    cookiejar "^2.1.0"
+    debug "^3.1.0"
+    extend "^3.0.0"
+    form-data "^2.3.1"
+    formidable "^1.2.0"
+    methods "^1.1.1"
+    mime "^1.4.1"
+    qs "^6.5.1"
+    readable-stream "^2.3.5"
+
+supertest@^4.0.2:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/supertest/-/supertest-4.0.2.tgz#c2234dbdd6dc79b6f15b99c8d6577b90e4ce3f36"
+  integrity sha512-1BAbvrOZsGA3YTCWqbmh14L0YEq0EGICX/nBnfkfVJn7SrxQV1I3pMYjSzG9y/7ZU2V9dWqyqk2POwxlb09duQ==
+  dependencies:
+    methods "^1.1.2"
+    superagent "^3.8.3"
 
 supports-color@^5.3.0:
   version "5.5.0"
@@ -19054,6 +19277,11 @@ type-fest@^0.8.1:
   version "0.8.1"
   resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.8.1.tgz#09e249ebde851d3b1e48d27c105444667f17b83d"
   integrity sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==
+
+type-fest@^1.2.2:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-1.4.0.tgz#e9fb813fe3bf1744ec359d55d1affefa76f14be1"
+  integrity sha512-yGSza74xk0UG8k+pLh5oeoYirvIiWo5t0/o3zHHAO2tRDiZcxWP7fywNlXhqb6/r6sWvwi+RsyQMWhVLe4BVuA==
 
 type-is@~1.6.18:
   version "1.6.18"
@@ -20088,7 +20316,7 @@ yargs@^16.2.0:
     y18n "^5.0.5"
     yargs-parser "^20.2.2"
 
-yargs@^17.1.1, yargs@^17.2.1:
+yargs@^17.0.1, yargs@^17.1.1, yargs@^17.2.1:
   version "17.5.1"
   resolved "https://registry.yarnpkg.com/yargs/-/yargs-17.5.1.tgz#e109900cab6fcb7fd44b1d8249166feb0b36e58e"
   integrity sha512-t6YAJcxDkNX7NFYiVtKvWUz8l+PaKTLiL63mJYWR2GnHq2gjEWISzsLp9wg3aY36dY1j+gfIEL3pIF+XlJJfbA==


### PR DESCRIPTION
Part of #102 

Create a plugin that will server as the backend for showing the status of clusters.

Blocked by https://github.com/operate-first/apps/pull/2439

Plugin API has 2 endpoints:
- `{addr}/api/cluster-status/status/{cluster-name}` -- get status for one chosen cluster
- `{addr}/api/cluster-status/status` -- get status for all configured clusters

Plugin adds a top level configuration field in the config files:
- `.clusterStatus.acmCluster` -- name of the ACM cluster to query for the status of all other configured clusters

Documentation will be added later to the backstage docs page.