### PR TITLE
fix: Use the correct value for retention-full

### DIFF
--- a/manifests/base/postgres.yaml
+++ b/manifests/base/postgres.yaml
@@ -23,7 +23,7 @@ spec:
       image: registry.developers.crunchydata.com/crunchydata/crunchy-pgbackrest:ubi8-2.38-0
       global:
         # Save backups for 14 days, this means 2 full backups with 6 differential ones in between
-        repo1-retention-full: "7"
+        repo1-retention-full: "1"
         repo1-retention-full-type: count
       repoHost:
         resources:


### PR DESCRIPTION
DB volume got used up again I think this time its because I understood the configuration incorrectly and thought the old value would keep 1 full and 6 differential backups, it seems like its keeping 7 full backups instead of just 1 full backup.

This change should tell the operator to only keep 1 full backup.