### PR TITLE
fix: Use the correct version of a package

### DIFF
--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -25,7 +25,7 @@
     "@backstage/plugin-auth-backend": "^0.14.0",
     "@backstage/plugin-badges-backend": "^0.1.27",
     "@backstage/plugin-catalog-backend": "^1.1.2",
-    "@backstage/plugin-catalog-common": "^1.0.5",
+    "@backstage/plugin-catalog-common": "^1.0.2",
     "@backstage/plugin-kubernetes-backend": "^0.6.0",
     "@backstage/plugin-permission-backend": "^0.5.7",
     "@backstage/plugin-permission-common": "^0.6.1",


### PR DESCRIPTION
Service catalog is failing since it can't find a module, I think this might be happening because a different version of the same module is being used in the apps [`package.json`](https://github.com/operate-first/service-catalog/blob/main/packages/app/package.json#L21) file. Changing the dependency to the same version should fix the issue, I tested in on a dev cluster.

See the original error here:

```sh
node:internal/modules/cjs/loader:361
      throw err;
      ^

Error: Cannot find module '/opt/app-root/src/packages/backend/dist/index.cjs.js'. Please verify that the package.json has a valid "main" entry
    at tryPackage (node:internal/modules/cjs/loader:353:19)
    at Function.Module._findPath (node:internal/modules/cjs/loader:566:18)
    at resolveMainPath (node:internal/modules/run_main:19:25)
    at Function.executeUserEntryPoint [as runMain] (node:internal/modules/run_main:71:24)
    at node:internal/main/run_main_module:17:47 {
  code: 'MODULE_NOT_FOUND',
  path: '/opt/app-root/src/packages/backend/package.json',
  requestPath: '/opt/app-root/src/packages/backend'
}

```