### PR TITLE
chore: Improve dev overlay for k8s deployment

### DIFF
--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -58,7 +58,9 @@ For local development with the kubernetes plugin, kubectl proxy is by default st
 
 ### Run in a Kubernetes cluster
 
-Configurations for the cluster dev setup are in `app-config.dev.yaml`.
+Configurations for the cluster dev setup are in `app-config.dev.yaml`. Make sure to edit the `.app.baseUrl`, `.backend.baseUrl` and `.backend.cors.origin` urls to the address backstage will be hosted on.
+
+Some plugins require secrets to function, they can configured in the `manifests/overlays/dev/secret.yaml` file.
 
 1. Update the image repository URL with your image repository:
 

--- a/manifests/base/deployment.yaml
+++ b/manifests/base/deployment.yaml
@@ -28,8 +28,6 @@ spec:
           envFrom:
             - secretRef:
                 name: service-catalog-pguser-service-catalog
-            - secretRef:
-                name: service-catalog-k8s-plugin-tokens
           env:
             - name: NODE_ENV
             - name: BACKEND_SECRET

--- a/manifests/overlays/dev/secret.yaml
+++ b/manifests/overlays/dev/secret.yaml
@@ -6,7 +6,7 @@ metadata:
     kustomize.config.k8s.io/behavior: replace
 stringData:
   BACKEND_SECRET: secret
-  ARGOCD_AUTH_TOKEN:
-  AUTH_GITHUB_CLIENT_ID:
-  AUTH_GITHUB_CLIENT_SECRET:
-  GRAFANA_TOKEN:
+  ARGOCD_AUTH_TOKEN: secret
+  AUTH_GITHUB_CLIENT_ID: secret
+  AUTH_GITHUB_CLIENT_SECRET: secret
+  GRAFANA_TOKEN: secret

--- a/manifests/overlays/prod/kustomization.yaml
+++ b/manifests/overlays/prod/kustomization.yaml
@@ -22,6 +22,11 @@ patches:
       - op: add
         path: /spec/template/spec/containers/0/envFrom/-
         value:
+          secretRef:
+            name: service-catalog-k8s-plugin-tokens
+      - op: add
+        path: /spec/template/spec/containers/0/envFrom/-
+        value:
           configMapRef:
             name: service-catalog-bucket-claim
     target:


### PR DESCRIPTION
- Add better documentation
- Add default values to plugin secrets
- Move `service-catalog-k8s-plugin-tokens` secret requirement from base overlay to prod