### PR TITLE
feat: Add clusterwide status page

### DIFF
--- a/packages/app/src/App.tsx
+++ b/packages/app/src/App.tsx
@@ -34,6 +34,7 @@ import { PermissionedRoute } from '@backstage/plugin-permission-react';
 import { catalogEntityCreatePermission } from '@backstage/plugin-catalog-common/alpha';
 import { HomepageCompositionRoot } from '@backstage/plugin-home';
 import { HomePage } from './components/home/HomePage';
+import { ClusterStatusPage } from './components/clusterStatusPage/ClusterStatusPage';
 
 import { badgesPlugin } from '@backstage/plugin-badges'
 import { grafanaPlugin } from '@k-phoen/backstage-plugin-grafana';
@@ -65,6 +66,9 @@ const routes = (
   <FlatRoutes>
     <Route path="/" element={<HomepageCompositionRoot />}>
       <HomePage />
+    </Route>
+    <Route path="/clusterStatusPage">
+      <ClusterStatusPage />
     </Route>
     <Route path="/catalog" element={<CatalogIndexPage />} />
     <Route

--- a/packages/app/src/clusterClient.ts
+++ b/packages/app/src/clusterClient.ts
@@ -1,0 +1,16 @@
+import { ConfigApi } from "@backstage/core-plugin-api";
+import { ClusterDetails } from "@internal/plugin-cluster-status-backend";
+
+export const getClusters = async (configApi: ConfigApi): Promise<ClusterDetails[]> => {
+  return clusterApiFetchCall(configApi, '')
+}
+
+export const getClusterByName = async (configApi: ConfigApi, name: string): Promise<ClusterDetails> => {
+  return clusterApiFetchCall(configApi, `/${name}`)
+}
+
+const clusterApiFetchCall = (configApi: ConfigApi, params: string): Promise<any> => {
+  const backendUrl = configApi.getString('backend.baseUrl');
+  const jsonResponse = fetch(`${backendUrl}/api/cluster-status/status${params}`).then(r => r.json())
+  return jsonResponse;
+}

--- a/packages/app/src/clusterClient.ts
+++ b/packages/app/src/clusterClient.ts
@@ -1,16 +1,25 @@
 import { ConfigApi } from "@backstage/core-plugin-api";
 import { ClusterDetails } from "@internal/plugin-cluster-status-backend";
 
-export const getClusters = async (configApi: ConfigApi): Promise<ClusterDetails[]> => {
-  return clusterApiFetchCall(configApi, '')
-}
+export const getClusters = async (
+  configApi: ConfigApi
+): Promise<ClusterDetails[]> => (
+  clusterApiFetchCall(configApi, '')
+)
 
-export const getClusterByName = async (configApi: ConfigApi, name: string): Promise<ClusterDetails> => {
-  return clusterApiFetchCall(configApi, `/${name}`)
-}
+export const getClusterByName = async (
+  configApi: ConfigApi,
+  name: string
+): Promise<ClusterDetails> => (
+  clusterApiFetchCall(configApi, `/${name}`)
+)
 
-const clusterApiFetchCall = (configApi: ConfigApi, params: string): Promise<any> => {
+const clusterApiFetchCall = (
+  configApi: ConfigApi,
+  params: string
+): Promise<any> => {
   const backendUrl = configApi.getString('backend.baseUrl');
-  const jsonResponse = fetch(`${backendUrl}/api/cluster-status/status${params}`).then(r => r.json())
+  const jsonResponse = fetch(`${backendUrl}/api/cluster-status/status${params}`)
+    .then(r => r.json())
   return jsonResponse;
 }

--- a/packages/app/src/components/Root/Root.tsx
+++ b/packages/app/src/components/Root/Root.tsx
@@ -20,6 +20,7 @@ import HomeIcon from '@material-ui/icons/Home';
 // import ExtensionIcon from '@material-ui/icons/Extension';
 // import MapIcon from '@material-ui/icons/MyLocation';
 import CategoryIcon from '@material-ui/icons/Category';
+import StorageIcon from '@material-ui/icons/Storage';
 // import CreateComponentIcon from '@material-ui/icons/AddCircleOutline';
 import Logo from '../Logo/Logo';
 import { NavLink } from 'react-router-dom';
@@ -88,8 +89,8 @@ export const Root = ({ children }: PropsWithChildren<{}>) => (
       <SidebarGroup label="Menu" icon={<MenuIcon />}>
         {/* Global nav, not org-specific */}
         <SidebarItem icon={HomeIcon} to="/" text="Home" />
+        <SidebarItem icon={StorageIcon} to="clusterStatusPage" text="Clusters" />
         <SidebarItem icon={CategoryIcon} to="catalog" text="Catalog" />
-        {/* <SidebarItem icon={ExtensionIcon} to="api-docs" text="APIs" /> */}
         {/* <SidebarItem icon={LibraryBooks} to="docs" text="Docs" /> */}
         {/* <SidebarItem icon={CreateComponentIcon} to="create" text="Create..." /> */}
         {/* End global nav */}

--- a/packages/app/src/components/clusterStatusPage/ClusterStatusPage.tsx
+++ b/packages/app/src/components/clusterStatusPage/ClusterStatusPage.tsx
@@ -1,0 +1,178 @@
+import React, { useState } from 'react';
+import { SearchContextProvider } from '@backstage/plugin-search-react';
+import {
+  Content,
+  Page,
+  InfoCard,
+  WarningPanel,
+  CodeSnippet,
+  StatusOK,
+  StatusError,
+  StatusPending,
+} from '@backstage/core-components';
+import {
+  CircularProgress,
+  Grid,
+  makeStyles,
+  Typography,
+} from '@material-ui/core';
+
+import { catalogApiRef, EntityRefLink } from '@backstage/plugin-catalog-react';
+import useAsyncFn from 'react-use/lib/useAsyncFn';
+import useDebounce from 'react-use/lib/useDebounce';
+import { configApiRef, useApi } from '@backstage/core-plugin-api';
+import { Entity } from '@backstage/catalog-model';
+import { getClusters } from '../../clusterClient';
+import { HomePageCompanyLogo } from '@backstage/plugin-home';
+import Logo from '../Logo/Logo';
+
+interface clusterEntity {
+  status: boolean,
+  clusterEntity: Entity
+}
+
+const useStyles = makeStyles(theme => ({
+  container: {
+    margin: theme.spacing(5, 0),
+  },
+  svg: {
+    width: 'auto',
+    height: 150,
+  },
+  typography: {
+    display: 'flex',
+    padding: '8px 0',
+    margin: 'auto',
+  },
+}));
+
+const useCatalogStyles = makeStyles({
+  root: {
+    height: '100%',
+    transition: 'all .25s linear',
+    textAlign: 'center',
+    '&:hover': {
+      boxShadow: '0px 0px 16px 0px rgba(0,0,0,0.8)',
+    },
+    '& svg': {
+      fontSize: 80,
+    },
+    '& img': {
+      height: 80,
+      width: 80,
+      objectFit: 'contain',
+    },
+  },
+  subheader: {
+    display: 'block',
+    width: '100%',
+  },
+  link: {
+    '&:hover': {
+      textDecoration: 'none',
+    },
+  },
+});
+
+const CatalogClusters = () => {
+  const catalogApi = useApi(catalogApiRef);
+  const configApi = useApi(configApiRef);
+  const classes = useCatalogStyles();
+
+  const [clusterEntities, setClusterEntities] = useState<clusterEntity[]>([]);
+  const [{ loading, error }, refresh] = useAsyncFn(
+    async () => {
+      const response = await catalogApi.getEntities();
+      const clusters = await getClusters(configApi)
+
+      const clusterResourceEntities = response.items.filter(
+        e => (
+          e.kind === 'Resource' &&
+          e.spec?.type === 'cluster'
+        )
+      );
+
+      setClusterEntities(clusterResourceEntities.map(entity => {
+        const cluster = clusters.find(cd => (
+          cd.name === entity.metadata.name
+        ))
+        return {
+          // !! --> converts object to boolean
+          status: !!cluster?.status.available!,
+          clusterEntity: entity,
+        }
+      }));
+    },
+    [catalogApi],
+    { loading: true },
+  );
+  useDebounce(refresh, 10);
+
+  if (error) {
+    return (
+      <WarningPanel severity="error" title="Could not fetch catalog entities.">
+        <CodeSnippet language="text" text={error.toString()} />
+      </WarningPanel>
+    );
+  }
+
+  if (loading) {
+    return <CircularProgress />;
+  }
+
+  return (
+    <>
+      {clusterEntities.map(item => (
+        <Grid item xs={12} sm={6} md={4} lg={3} xl={2} key={item.clusterEntity.metadata.name}>
+          <EntityRefLink entityRef={item.clusterEntity} className={classes.link}>
+            <InfoCard
+              className={classes.root}
+              title={
+                <div className={classes.subheader}>
+                  {
+                    item.status === true ? <StatusOK></StatusOK>
+                      : item.status === false ? <StatusError></StatusError>
+                        : <StatusPending></StatusPending>
+                  }
+                  {item.clusterEntity.metadata.title || item.clusterEntity.metadata.name}
+                </div>
+              }
+            >
+              <Typography paragraph>{item.clusterEntity.metadata.description}</Typography>
+            </InfoCard>
+          </EntityRefLink>
+        </Grid>
+      ))}
+    </>
+  );
+};
+
+export const ClusterStatusPage = () => {
+  const { svg, container, typography } = useStyles();
+
+  return (
+    <SearchContextProvider>
+      <Page themeId="clusters">
+        <Content>
+          <Grid container justifyContent="center" spacing={6}>
+            <HomePageCompanyLogo
+              className={container}
+              logo={<Logo classes={{ svg }} />}
+            />
+            <Grid container item xs={12} alignItems="center" direction="row">
+              <Typography
+                variant='h1'
+                className={typography}
+              >
+                Clusters
+              </Typography>
+            </Grid>
+            <Grid container item xs={12} justifyContent="center" >
+              <CatalogClusters />
+            </Grid>
+          </Grid>
+        </Content>
+      </Page>
+    </SearchContextProvider>
+  );
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -1760,15 +1760,6 @@
     cross-fetch "^3.1.5"
     serialize-error "^8.0.1"
 
-"@backstage/errors@^1.1.0":
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/@backstage/errors/-/errors-1.1.0.tgz#7e2376f8d0e5d58422b43a1551e5d980173acb7b"
-  integrity sha512-cWy7TpjrUvsMJ74et1PFvh0YYzzLDtK4qGJTwmF5AQBTZbNsi1UlNYET0sPVdlWbr6FRqa1QQNZwUkvpllB6YQ==
-  dependencies:
-    "@backstage/types" "^1.0.0"
-    cross-fetch "^3.1.5"
-    serialize-error "^8.0.1"
-
 "@backstage/integration-react@^1.0.0", "@backstage/integration-react@^1.1.1":
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/@backstage/integration-react/-/integration-react-1.1.1.tgz#936fd1441c47709fa8825360ea14ada26046b910"
@@ -2051,14 +2042,6 @@
   dependencies:
     "@backstage/plugin-permission-common" "^0.6.2"
     "@backstage/plugin-search-common" "^0.3.5"
-
-"@backstage/plugin-catalog-common@^1.0.5":
-  version "1.0.5"
-  resolved "https://registry.yarnpkg.com/@backstage/plugin-catalog-common/-/plugin-catalog-common-1.0.5.tgz#0617387e52181ea347b505d00704b791eef2dcda"
-  integrity sha512-dBKSBHPlohL3aHVGZLKGZfHtEnWzH1bwWCTJlqJLdiyfiRWjwtgRTIlcv2GSizYs4WZ1IW1LfDxkheR0pAW8vg==
-  dependencies:
-    "@backstage/plugin-permission-common" "^0.6.3"
-    "@backstage/plugin-search-common" "^1.0.0"
 
 "@backstage/plugin-catalog-graph@^0.2.17":
   version "0.2.17"
@@ -2356,17 +2339,6 @@
     uuid "^8.0.0"
     zod "^3.11.6"
 
-"@backstage/plugin-permission-common@^0.6.3":
-  version "0.6.3"
-  resolved "https://registry.yarnpkg.com/@backstage/plugin-permission-common/-/plugin-permission-common-0.6.3.tgz#9815dd2dddf224454f55f35710b6a68644e95f00"
-  integrity sha512-7GL3+9M2wDiG406JSIzTq08KNrSZToAG5PTwKHXD6RFC1jF9X50aRYv+5jVwdmRhSk6r5JqoB4HhcgisseBzoQ==
-  dependencies:
-    "@backstage/config" "^1.0.1"
-    "@backstage/errors" "^1.1.0"
-    cross-fetch "^3.1.5"
-    uuid "^8.0.0"
-    zod "^3.11.6"
-
 "@backstage/plugin-permission-node@^0.6.1":
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/@backstage/plugin-permission-node/-/plugin-permission-node-0.6.1.tgz#dbdc87eff8fd51eda0381ed5582a2caa46f4d86d"
@@ -2586,14 +2558,6 @@
   integrity sha512-sq7IDjCLrgZQHBFi+lFVkna3lLRA5eldiTbit/rCUCO4Eq52lWdQHLrQAhsyuObmIWHDh6R2lp2qoL6aAC2AOg==
   dependencies:
     "@backstage/plugin-permission-common" "^0.6.2"
-    "@backstage/types" "^1.0.0"
-
-"@backstage/plugin-search-common@^1.0.0":
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/@backstage/plugin-search-common/-/plugin-search-common-1.0.0.tgz#fa9ac1f57d79e7cd9b9ca9a929065979010a5a37"
-  integrity sha512-Jr+z/cqc60GkY7rrIXifmAIdlRbEFtWesoLx5v4rgLGG/lCgsMzAm0Vxzg1g/9r71raSnKBakPajjhpMEZ5SWA==
-  dependencies:
-    "@backstage/plugin-permission-common" "^0.6.3"
     "@backstage/types" "^1.0.0"
 
 "@backstage/plugin-search-react@^0.2.0":
@@ -5855,7 +5819,7 @@
   resolved "https://registry.yarnpkg.com/@types/range-parser/-/range-parser-1.2.4.tgz#cd667bcfdd025213aafb7ca5915a932590acdcdc"
   integrity sha512-EEhsLsD6UsDM1yFhAvy0Cjr6VwmpMWqFBCb9w07wVugF7w9nfajxLuVmngTIpgS6svCnm6Vaw+MZhoDCKnOfsw==
 
-"@types/react-dom@*", "@types/react-dom@<18.0.0":
+"@types/react-dom@*", "@types/react-dom@<18.0.0", "@types/react-dom@^17":
   version "17.0.17"
   resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-17.0.17.tgz#2e3743277a793a96a99f1bf87614598289da68a1"
   integrity sha512-VjnqEmqGnasQKV0CWLevqMTXBYG9GbwuE6x3VetERLh0cq2LTptFE73MrQi2S7GkKXCf2GgwItB/melLnxfnsg==


### PR DESCRIPTION
Part of #102 

Add a frontend client to call the required endpoints for the backend `cluster-status` plugin.

Add a single page to show the overlap of configured cluster and resources with `kind: cluster`. Each entry displays the cluster name, status and description. It uses the data from the backend `cluster-status` plugin. See the image bellow for an example.

![image](https://user-images.githubusercontent.com/44006847/192841695-ef1ea34f-0d9e-491d-8904-b24ab3987e14.png)
