### PR TITLE
feat: Add component to display cluster details

### DIFF
--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -36,6 +36,7 @@
     "@backstage/plugin-user-settings": "^0.4.8",
     "@backstage/theme": "^0.2.16",
     "@k-phoen/backstage-plugin-grafana": "^0.1.14",
+    "@internal/plugin-cluster-status-backend": "*",
     "@material-ui/core": "^4.12.2",
     "@material-ui/icons": "^4.9.1",
     "@roadiehq/backstage-plugin-argo-cd": "^2.1.9",

--- a/packages/app/src/clusterClient.ts
+++ b/packages/app/src/clusterClient.ts
@@ -1,6 +1,17 @@
 import { ConfigApi } from "@backstage/core-plugin-api";
 import { ClusterDetails } from "@internal/plugin-cluster-status-backend";
 
+
+const clusterApiFetchCall = (
+  configApi: ConfigApi,
+  params: string
+): Promise<any> => {
+  const backendUrl = configApi.getString('backend.baseUrl');
+  const jsonResponse = fetch(`${backendUrl}/api/cluster-status/status${params}`)
+    .then(r => r.json())
+  return jsonResponse;
+}
+
 export const getClusters = async (
   configApi: ConfigApi
 ): Promise<ClusterDetails[]> => (
@@ -13,13 +24,3 @@ export const getClusterByName = async (
 ): Promise<ClusterDetails> => (
   clusterApiFetchCall(configApi, `/${name}`)
 )
-
-const clusterApiFetchCall = (
-  configApi: ConfigApi,
-  params: string
-): Promise<any> => {
-  const backendUrl = configApi.getString('backend.baseUrl');
-  const jsonResponse = fetch(`${backendUrl}/api/cluster-status/status${params}`)
-    .then(r => r.json())
-  return jsonResponse;
-}

--- a/packages/app/src/components/catalog/ClusterStatus.tsx
+++ b/packages/app/src/components/catalog/ClusterStatus.tsx
@@ -1,0 +1,99 @@
+import React, { useState } from "react";
+import {
+  Card,
+  CardContent,
+  CardHeader,
+  List,
+  ListItem,
+  ListItemText
+} from "@material-ui/core";
+import { configApiRef, useApi } from "@backstage/core-plugin-api";
+import { useEntity } from "@backstage/plugin-catalog-react";
+import { getClusterByName } from "../../clusterClient";
+import useAsyncFn from 'react-use/lib/useAsyncFn';
+import useDebounce from "react-use/lib/useDebounce";
+import { ClusterDetails } from "@internal/plugin-cluster-status-backend";
+
+interface props {
+  cluster: Object
+}
+
+const convertToGibibytes = (kibibytes: string): string => {
+  const sizeInKibibytes = parseInt(kibibytes.substring(0, kibibytes.length - 2), 10)
+  return `${(sizeInKibibytes / 2 ** 20).toFixed(0)} Gi`
+}
+
+const fixName = (val: string): string => (
+  val.replace(/[A-Z]/g, v => (` ${v.toLowerCase()}`))
+    .replace(/^\w/g, v => v.toUpperCase())
+)
+
+const ClusterDetailsContent = (
+  { cluster }: props
+) => {
+  return (
+    <List >
+      {
+        Object.entries(cluster).map(e => {
+          const name = e[0]
+          const value = e[1]
+          const primary = `${fixName(name)}:`
+          let secondary: string = value.toString()
+
+          if (!(typeof value === 'string' || typeof value === 'boolean')) {
+            return (
+              <ListItem key={name}>
+                <ListItemText
+                  primary={primary}
+                  secondary={<ClusterDetailsContent cluster={value} />}
+                />
+              </ListItem>
+            )
+          }
+          else if (secondary.substring(secondary.length - 2) === 'Ki') {
+            secondary = convertToGibibytes(secondary)
+          }
+          return (
+            <ListItem key={name}>
+              <ListItemText
+                primary={primary}
+                secondary={secondary}
+              />
+            </ListItem>
+          )
+        })
+      }
+    </List>
+  )
+}
+
+export const ClusterStatus = () => {
+  const { entity } = useEntity();
+  const configApi = useApi(configApiRef);
+  const [cluster, setCluster] = useState<ClusterDetails>({
+    status: {
+      available: false,
+      reason: 'loading'
+    }
+  });
+  const [_, refresh] = useAsyncFn(
+    async () => {
+      const thisCluster = await getClusterByName(configApi, entity.metadata.name)
+      setCluster(thisCluster)
+    }, [], { loading: true }
+  );
+  useDebounce(refresh, 10);
+
+  return (
+    <Card>
+      <CardHeader
+        title='Cluster status'
+      />
+      <CardContent>
+        <ClusterDetailsContent cluster={cluster} />
+      </CardContent>
+    </Card>
+  );
+}
+
+export default ClusterStatus;

--- a/packages/app/src/components/catalog/resource.tsx
+++ b/packages/app/src/components/catalog/resource.tsx
@@ -8,6 +8,7 @@ import {
   isTechDocsAvailable,
 } from '@backstage/plugin-techdocs';
 import OverviewWrapper from './shared/OverviewWrapper';
+import ClusterStatus from './ClusterStatus';
 
 const resource = (
   <LayoutWrapper>
@@ -16,7 +17,7 @@ const resource = (
         <Grid item xs={12}>
           <EntitySwitch>
             <EntitySwitch.Case if={isType('cluster')}>
-              <p>Cluster Overview Goes Here</p>
+              <ClusterStatus />
             </EntitySwitch.Case>
           </EntitySwitch>
         </Grid>

--- a/packages/app/src/components/clusterStatusPage/ClusterStatusPage.tsx
+++ b/packages/app/src/components/clusterStatusPage/ClusterStatusPage.tsx
@@ -171,3 +171,5 @@ export const ClusterStatusPage = () => {
     </SearchContextProvider>
   );
 };
+
+export default ClusterStatusPage;

--- a/yarn.lock
+++ b/yarn.lock
@@ -5722,7 +5722,7 @@
   resolved "https://registry.yarnpkg.com/@types/range-parser/-/range-parser-1.2.4.tgz#cd667bcfdd025213aafb7ca5915a932590acdcdc"
   integrity sha512-EEhsLsD6UsDM1yFhAvy0Cjr6VwmpMWqFBCb9w07wVugF7w9nfajxLuVmngTIpgS6svCnm6Vaw+MZhoDCKnOfsw==
 
-"@types/react-dom@*", "@types/react-dom@<18.0.0", "@types/react-dom@^17":
+"@types/react-dom@*", "@types/react-dom@<18.0.0":
   version "17.0.17"
   resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-17.0.17.tgz#2e3743277a793a96a99f1bf87614598289da68a1"
   integrity sha512-VjnqEmqGnasQKV0CWLevqMTXBYG9GbwuE6x3VetERLh0cq2LTptFE73MrQi2S7GkKXCf2GgwItB/melLnxfnsg==


### PR DESCRIPTION
Part of #102 

Add a component that shows detailed information about a cluster. It uses the data from the backend `cluster-status` plugin. This is an early version, it will be implemented better in a future PR. See the image bellow for an example.

![image](https://user-images.githubusercontent.com/44006847/192843038-661e34cf-a626-4663-951c-a61bd3baa098.png)
