### PR TITLE
fix: Add gzip installation to image

### DIFF
--- a/.github/actions/build-service-catalog/action.yaml
+++ b/.github/actions/build-service-catalog/action.yaml
@@ -8,16 +8,15 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - name: Read S2I base image
-      id: s2ibase
-      uses: juliangruber/read-file-action@v1
-      with:
-        path: ./.s2ibase
+    - name: Install S2I
+      shell: bash
+      run: |
+        mkdir -p ~/.local/bin
+        curl \
+          https://api.github.com/repos/openshift/source-to-image/releases/latest | \
+          grep "browser_download_url.*linux-amd64" | cut -d '"' -f 4 | \
+          wget -qO - -i - | tar xzv -C ~/.local/bin
 
     - name: S2I Build
-      uses: redhat-actions/s2i-build@v2
-      with:
-        path_context: "."
-        builder_image: "${{ steps.s2ibase.outputs.content }}"
-        image: service-catalog
-        tags: "${{ inputs.tags }}"
+      shell: bash
+      run: ./packages/backend/build-image.sh "${{ inputs.tags }}"

--- a/packages/backend/build-image.sh
+++ b/packages/backend/build-image.sh
@@ -18,8 +18,17 @@ echo "---> Run s2i build"
 s2i build . ${NODEJS_BASE_IMAGE} --as-dockerfile ${tmp_dir}/Containerfile
 cd $tmp_dir
 
+# Install gzip as root before the user switches to 1001
+sed -i '/USER root/a RUN microdnf install -y gzip' Containerfile
+
 echo "---> Create image"
 podman build -t service-catalog .
+
+# Add tags to image
+if ! [[ $# -eq 0 ]] ; then
+  tags=$(echo "$@" | xargs printf -- 'localhost/service-catalog:%s ')
+  podman tag localhost/service-catalog $tags
+fi
 
 echo "---> Clean up"
 rm -rf $tmp_dir


### PR DESCRIPTION
Resolves #110 

I am not sure if this is the best approach to solve this. I wanted to add the gzip installation to the assemble script but `microdnf` only works with root permissions. Instead I added the gzip install manually to the generated Dockerfile and use the `build-image.sh` script to build the image in the workflow instead of using the github action for s2i since I don't think it uses the `build-image.sh script.

/cc @tumido @mimotej 