### PR TITLE
hotfix: Lock S2I base image

### DIFF
--- a/.s2ibase
+++ b/.s2ibase
@@ -1,1 +1,1 @@
-registry.access.redhat.com/ubi9/nodejs-16-minimal:latest
+registry.access.redhat.com/ubi9/nodejs-16-minimal:1-60


### PR DESCRIPTION
Resolves: #110
Replaces: #115

We've discovered `gzip` is removed from latest `ubiX/minimal` base images... I'll investigate further. For now, let's lock to previous revision.

https://catalog.redhat.com/software/containers/ubi9/nodejs-16-minimal/61a6059abfd4a5234d59621f?tag=1-67&push_date=1663685796000&container-tabs=packages

![image](https://user-images.githubusercontent.com/7453394/193636239-17e6271b-7c07-443b-8b84-96822322689a.png)


https://catalog.redhat.com/software/containers/ubi9/ubi-minimal/615bd9b4075b022acc111bf5?tag=9.0.0-1644&push_date=1663685323000&container-tabs=packages

![image](https://user-images.githubusercontent.com/7453394/193635969-aa7d1fa9-7086-4de9-9d6f-973105c0c93d.png)
