### PR TITLE
fix: Correctly check if cluster name exists in config

### DIFF
--- a/plugins/cluster-status-backend/src/statusCheck/StatusCheck.ts
+++ b/plugins/cluster-status-backend/src/statusCheck/StatusCheck.ts
@@ -118,8 +118,8 @@ export class StatusCheck {
 
   private checkClusterNames = (clusterName: string) => {
     const clusters = this.getClustersFromConfig();
-    if (clusters.some((value) => (
-      value.getString('name') !== clusterName
+    if (!clusters.some((value) => (
+      value.getString('name') === clusterName
     ))) {
       throw new Error(`${clusterName} cluster is not contained in the config file`);
     }


### PR DESCRIPTION
The check whether a cluster name existed in the config file was incorrect.