### PR TITLE
feat: Show/hide additional deployment related info for System/Component

### DIFF
--- a/packages/app/src/components/catalog/component.tsx
+++ b/packages/app/src/components/catalog/component.tsx
@@ -36,6 +36,7 @@ import { EntityKubernetesContent } from '@backstage/plugin-kubernetes';
 import OverviewWrapper from './shared/OverviewWrapper';
 import { HorizontalScrollGrid, StatusOK } from '@backstage/core-components';
 import StatusCard from './shared/StatusCard';
+import { isType } from './shared/utils';
 
 const component = (
   <LayoutWrapper>
@@ -73,33 +74,37 @@ const component = (
                 No issues found
               </Typography>
             </StatusCard>
-            <div style={{ margin: 12, minWidth: 311, display: 'flex' }}>
-              <SecurityInsightsWidget />
-            </div>
-            <StatusCard
-              title="Deployment"
-              deepLink={{ title: 'View more', link: 'kubernetes' }}
-            >
-              <Typography variant="h1" component="div">
-                <StatusOK />
-              </Typography>
-              <Typography variant="subtitle2" component="div">
-                1 deployment ready, no errors
-              </Typography>
-            </StatusCard>
-            <StatusCard
-              title="Alerts"
-              deepLink={{ title: 'View more', link: 'kubernetes' }}
-            >
-              <Typography variant="h1" component="div">
-                0
-              </Typography>
-              <Typography variant="subtitle2" component="div">
-                No alerts firing
-              </Typography>
-            </StatusCard>
+            <EntitySwitch>
+              <EntitySwitch.Case if={isType(['service', 'operator'])}>
+                <StatusCard
+                  title="Deployment"
+                  deepLink={{ title: 'View more', link: 'kubernetes' }}
+                >
+                  <Typography variant="h1" component="div">
+                    <StatusOK />
+                  </Typography>
+                  <Typography variant="subtitle2" component="div">
+                    1 deployment ready, no errors
+                  </Typography>
+                </StatusCard>
+                <StatusCard
+                  title="Alerts"
+                  deepLink={{ title: 'View more', link: 'kubernetes' }}
+                >
+                  <Typography variant="h1" component="div">
+                    0
+                  </Typography>
+                  <Typography variant="subtitle2" component="div">
+                    No alerts firing
+                  </Typography>
+                </StatusCard>
+              </EntitySwitch.Case>
+            </EntitySwitch>
             <div style={{ margin: 12, minWidth: 400 }}>
               <DependabotAlertsWidget />
+            </div>
+            <div style={{ margin: 12, minWidth: 311, display: 'flex' }}>
+              <SecurityInsightsWidget />
             </div>
           </HorizontalScrollGrid>
         </Grid>
@@ -125,7 +130,7 @@ const component = (
       </Grid>
     </EntityLayout.Route>
 
-    <EntityLayout.Route path="/kubernetes" title="Openshift">
+    <EntityLayout.Route if={isType(['service', 'operator'])} path="/kubernetes" title="Openshift">
       <EntityKubernetesContent refreshIntervalMs={30000} />
     </EntityLayout.Route>
 

--- a/packages/app/src/components/catalog/system.tsx
+++ b/packages/app/src/components/catalog/system.tsx
@@ -4,6 +4,7 @@ import {
   EntityHasComponentsCard,
   EntityHasResourcesCard,
   EntityLayout,
+  EntitySwitch,
 } from '@backstage/plugin-catalog';
 import {
   Direction,
@@ -13,6 +14,8 @@ import { EntityHasApisCard } from '@backstage/plugin-api-docs';
 
 import LayoutWrapper from './shared/LayoutWrapper';
 import OverviewWrapper from './shared/OverviewWrapper';
+import { EntityKubernetesContent, isKubernetesAvailable } from '@backstage/plugin-kubernetes';
+import { EntityArgoCDOverviewCard, isArgocdAvailable } from '@roadiehq/backstage-plugin-argo-cd';
 
 const system = (
   <LayoutWrapper>
@@ -26,6 +29,13 @@ const system = (
             height={400}
           />
         </Grid>
+        <EntitySwitch>
+          <EntitySwitch.Case if={isArgocdAvailable}>
+            <Grid item xs={12}>
+              <EntityArgoCDOverviewCard />
+            </Grid>
+          </EntitySwitch.Case>
+        </EntitySwitch>
         <Grid item xs={12}>
           <EntityHasComponentsCard variant="gridItem" />
         </Grid>
@@ -36,6 +46,9 @@ const system = (
           <EntityHasResourcesCard variant="gridItem" />
         </Grid>
       </OverviewWrapper>
+    </EntityLayout.Route>
+    <EntityLayout.Route if={isKubernetesAvailable} path="/kubernetes" title="Openshift">
+      <EntityKubernetesContent refreshIntervalMs={30000} />
     </EntityLayout.Route>
   </LayoutWrapper>
 );


### PR DESCRIPTION
It can be beneficial on large systems to see Deployment status and ArgoCD aggregated across components (Prow)

On component level we should hide Kubernetes tab and Deployment related overview tiles for other types than `service` and `operator` 