### PR TITLE
fix: Add patch for service account name

### DIFF
--- a/manifests/overlays/dev/kustomization.yaml
+++ b/manifests/overlays/dev/kustomization.yaml
@@ -14,6 +14,9 @@ patches:
       - op: add
         path: /spec/template/spec/containers/0/env/0/value
         value: development
+      - op: add
+        path: /spec/template/spec/serviceAccountName
+        value: service-catalog-k8s-plugin
     target:
       kind: Deployment
       name: service-catalog


### PR DESCRIPTION
This patch is required so that the k8s plugin can be used in dev overlay.