### PR TITLE
feat: Setup postgres search

### DIFF
--- a/app-config.dev.yaml
+++ b/app-config.dev.yaml
@@ -46,3 +46,5 @@ kubernetes:
 
 clusterStatus:
   acmCluster: 'dev-cluster'
+
+searchInitialDelay: 30

--- a/app-config.local.yaml
+++ b/app-config.local.yaml
@@ -49,3 +49,5 @@ kubernetes:
 
 clusterStatus:
   acmCluster: 'dev-cluster'
+
+searchInitialDelay: 5

--- a/app-config.prod.yaml
+++ b/app-config.prod.yaml
@@ -106,3 +106,5 @@ kubernetes:
 
 clusterStatus:
   acmCluster: 'infra'
+
+searchInitialDelay: 30

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -34,6 +34,7 @@
     "@backstage/plugin-proxy-backend": "^0.2.30",
     "@backstage/plugin-scaffolder-backend": "^1.6.0",
     "@backstage/plugin-search-backend": "^1.0.2",
+    "@backstage/plugin-search-backend-module-pg": "^0.4.0",
     "@backstage/plugin-search-backend-node": "^1.0.2",
     "@backstage/plugin-techdocs-backend": "^1.3.0",
     "@internal/plugin-cluster-status-backend": "*",

--- a/packages/backend/src/plugins/search.ts
+++ b/packages/backend/src/plugins/search.ts
@@ -8,14 +8,16 @@ import { PluginEnvironment } from '../types';
 import { DefaultCatalogCollatorFactory } from '@backstage/plugin-catalog-backend';
 import { DefaultTechDocsCollatorFactory } from '@backstage/plugin-techdocs-backend';
 import { Router } from 'express';
+import { PgSearchEngine } from '@backstage/plugin-search-backend-module-pg'
 
 export default async function createPlugin(
   env: PluginEnvironment,
 ): Promise<Router> {
   // Initialize a connection to a search engine.
-  const searchEngine = new LunrSearchEngine({
-    logger: env.logger,
-  });
+  const searchEngine = (await PgSearchEngine.supported(env.database))
+    ? await PgSearchEngine.fromConfig(env.config, { database: env.database })
+    : new LunrSearchEngine({ logger: env.logger });
+
   const indexBuilder = new IndexBuilder({
     logger: env.logger,
     searchEngine,
@@ -26,7 +28,7 @@ export default async function createPlugin(
     timeout: { minutes: 15 },
     // A 3 second delay gives the backend server a chance to initialize before
     // any collators are executed, which may attempt requests against the API.
-    initialDelay: { seconds: 3 },
+    initialDelay: { seconds: 30 },
   });
 
   // Collators are responsible for gathering documents known to plugins. This

--- a/packages/backend/src/plugins/search.ts
+++ b/packages/backend/src/plugins/search.ts
@@ -26,9 +26,7 @@ export default async function createPlugin(
   const schedule = env.scheduler.createScheduledTaskRunner({
     frequency: { minutes: 10 },
     timeout: { minutes: 15 },
-    // A 3 second delay gives the backend server a chance to initialize before
-    // any collators are executed, which may attempt requests against the API.
-    initialDelay: { seconds: 30 },
+    initialDelay: { seconds: env.config.getNumber('searchInitialDelay') },
   });
 
   // Collators are responsible for gathering documents known to plugins. This

--- a/yarn.lock
+++ b/yarn.lock
@@ -2239,6 +2239,19 @@
     yaml "^2.0.0"
     zen-observable "^0.8.15"
 
+"@backstage/plugin-search-backend-module-pg@^0.4.0":
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/@backstage/plugin-search-backend-module-pg/-/plugin-search-backend-module-pg-0.4.0.tgz#8f7dabd56c4080791f2357a772bba20f8ea94527"
+  integrity sha512-6s6xoe1mJEbiazqJM2SLIhtUCIp5Ecwm7u01yx/FBeoCnyLOjo9a4UdwX1613+5DZIKixJoC9tQFblFdN7u5DA==
+  dependencies:
+    "@backstage/backend-common" "^0.15.1"
+    "@backstage/config" "^1.0.2"
+    "@backstage/plugin-search-backend-node" "^1.0.2"
+    "@backstage/plugin-search-common" "^1.0.1"
+    knex "^2.0.0"
+    lodash "^4.17.21"
+    uuid "^8.3.2"
+
 "@backstage/plugin-search-backend-node@^1.0.2":
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/@backstage/plugin-search-backend-node/-/plugin-search-backend-node-1.0.2.tgz#801bd0e56f0dc36250c4c0ae46090e24eb65e491"
@@ -5722,7 +5735,7 @@
   resolved "https://registry.yarnpkg.com/@types/range-parser/-/range-parser-1.2.4.tgz#cd667bcfdd025213aafb7ca5915a932590acdcdc"
   integrity sha512-EEhsLsD6UsDM1yFhAvy0Cjr6VwmpMWqFBCb9w07wVugF7w9nfajxLuVmngTIpgS6svCnm6Vaw+MZhoDCKnOfsw==
 
-"@types/react-dom@*", "@types/react-dom@<18.0.0", "@types/react-dom@^17":
+"@types/react-dom@*", "@types/react-dom@<18.0.0":
   version "17.0.17"
   resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-17.0.17.tgz#2e3743277a793a96a99f1bf87614598289da68a1"
   integrity sha512-VjnqEmqGnasQKV0CWLevqMTXBYG9GbwuE6x3VetERLh0cq2LTptFE73MrQi2S7GkKXCf2GgwItB/melLnxfnsg==


### PR DESCRIPTION
Depends on #133 

- Setup search to use postgres search
- Add configuration option for initial delay and set it to 30 sec for a k8s deployment so that the backend has time to start since the search plugin communicates with the backend to create indexes. [search docs](https://backstage.io/docs/features/search/getting-started#backend)