### PR TITLE
feat: Add cluster details to individual clusters

### DIFF
--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -52,6 +52,7 @@
     "@roadiehq/backstage-plugin-argo-cd": "^2.1.9",
     "@roadiehq/backstage-plugin-github-insights": "^2.0.6",
     "@roadiehq/backstage-plugin-security-insights": "^2.0.10",
+    "@internal/plugin-cluster-status-backend": "*",
     "history": "^5.0.0",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",

--- a/packages/app/src/clusterClient.ts
+++ b/packages/app/src/clusterClient.ts
@@ -1,6 +1,17 @@
 import { ConfigApi } from "@backstage/core-plugin-api";
 import { ClusterDetails } from "@internal/plugin-cluster-status-backend";
 
+
+const clusterApiFetchCall = (
+  configApi: ConfigApi,
+  params: string
+): Promise<any> => {
+  const backendUrl = configApi.getString('backend.baseUrl');
+  const jsonResponse = fetch(`${backendUrl}/api/cluster-status/status${params}`)
+    .then(r => r.json())
+  return jsonResponse;
+}
+
 export const getClusters = async (
   configApi: ConfigApi
 ): Promise<ClusterDetails[]> => (
@@ -13,13 +24,3 @@ export const getClusterByName = async (
 ): Promise<ClusterDetails> => (
   clusterApiFetchCall(configApi, `/${name}`)
 )
-
-const clusterApiFetchCall = (
-  configApi: ConfigApi,
-  params: string
-): Promise<any> => {
-  const backendUrl = configApi.getString('backend.baseUrl');
-  const jsonResponse = fetch(`${backendUrl}/api/cluster-status/status${params}`)
-    .then(r => r.json())
-  return jsonResponse;
-}

--- a/packages/app/src/components/catalog/resource.tsx
+++ b/packages/app/src/components/catalog/resource.tsx
@@ -8,6 +8,13 @@ import {
   isTechDocsAvailable,
 } from '@backstage/plugin-techdocs';
 import OverviewWrapper from './shared/OverviewWrapper';
+import {
+  ClusterAllocatableResourceTable,
+  ClusterAvaliableResourceTable,
+  ClusterContextProvider,
+  ClusterInfoTable,
+  ClusterStatusCard,
+} from './shared/ClusterStatus';
 
 const resource = (
   <LayoutWrapper>
@@ -16,7 +23,24 @@ const resource = (
         <Grid item xs={12}>
           <EntitySwitch>
             <EntitySwitch.Case if={isType('cluster')}>
-              <p>Cluster Overview Goes Here</p>
+              <ClusterContextProvider>
+                <Grid container>
+                  <Grid container item direction="column" xs={3}>
+                    <Grid item>
+                      <ClusterStatusCard />
+                    </Grid>
+                    <Grid item>
+                      <ClusterAllocatableResourceTable />
+                    </Grid>
+                    <Grid item>
+                      <ClusterAvaliableResourceTable />
+                    </Grid>
+                  </Grid>
+                  <Grid item xs>
+                    <ClusterInfoTable />
+                  </Grid>
+                </Grid>
+              </ClusterContextProvider>
             </EntitySwitch.Case>
           </EntitySwitch>
         </Grid>

--- a/packages/app/src/components/catalog/shared/ClusterStatus.tsx
+++ b/packages/app/src/components/catalog/shared/ClusterStatus.tsx
@@ -1,0 +1,218 @@
+/* eslint-disable no-nested-ternary */
+import React, { createContext, useContext, useState } from "react";
+import {
+  Card,
+  CardContent,
+  CardHeader,
+  Typography
+} from "@material-ui/core";
+import { configApiRef, useApi } from "@backstage/core-plugin-api";
+import { useEntity } from "@backstage/plugin-catalog-react";
+import useAsyncFn from 'react-use/lib/useAsyncFn';
+import useDebounce from "react-use/lib/useDebounce";
+import { ClusterDetails } from "@internal/plugin-cluster-status-backend";
+import {
+  InfoCard,
+  Link,
+  StatusAborted,
+  StatusError,
+  StatusOK,
+  Table
+} from "@backstage/core-components";
+import { getClusterByName } from "../../../clusterClient";
+
+
+const defaultClusterDetails: ClusterDetails = {
+  status: {
+    available: false,
+    reason: 'Loading'
+  }
+}
+
+const ClusterContext = createContext({
+  // Have to put a default cluster details since it has to have a status by definition
+  data: defaultClusterDetails,
+  loading: true,
+  error: false,
+});
+
+export const ClusterContextProvider = (props: any) => {
+  const { entity } = useEntity();
+  const configApi = useApi(configApiRef);
+  const [cluster, setCluster] = useState<ClusterDetails>(defaultClusterDetails);
+  const [{ loading, error }, refresh] = useAsyncFn(
+    async () => {
+      setCluster(await getClusterByName(configApi, entity.metadata.name))
+    }, [], { loading: true }
+  );
+  useDebounce(refresh, 10);
+
+  let errorBool = false
+  /*
+  Error can either be undefined or Error(), if its undefined, no error happended
+  if cluster has some 'error' key, it means the API sent back an error response
+  */
+  if (error instanceof Error || 'error' in cluster) {
+    errorBool = true
+  }
+
+  return (
+    <ClusterContext.Provider value={{ data: cluster, loading, error: errorBool }} >
+      {props.children}
+    </ClusterContext.Provider>
+  )
+}
+
+const convertToGibibytes = (kibibytes: string): string => {
+  const sizeInKibibytes = parseInt(kibibytes.substring(0, kibibytes.length - 2), 10)
+  return `${(sizeInKibibytes / 2 ** 20).toFixed(0)} Gi`
+}
+
+const valueFormatter = (value: any): any => {
+  if (typeof value === 'string') {
+    if (value.slice(-2) === 'Ki') {
+      return convertToGibibytes(value)
+    } else if (value.slice(0, 4) === 'http') {
+      return <Link to={value}>{value}</Link>
+    }
+  }
+  return value.toString()
+}
+
+const tableFromObject = (
+  data: any,
+  title: string,
+  nameMap: Map<string, string>
+) => {
+  const parsedData: { name: string; value: string; }[] = []
+  const entries = Object.entries(data)
+
+  nameMap.forEach((_, key) => {
+    const entry = entries.find(e => (
+      e[0] === key
+    ))!
+    // If key of the map doesnt have an prop in the cluster object, continue
+    if (entry === undefined) {
+      return
+    }
+    parsedData.push(
+      {
+        // entry[0] === name of the prop
+        name: nameMap.get(entry[0])!,
+        // entry[1] === value of the prop
+        value: valueFormatter(entry[1])
+      }
+    )
+  })
+
+  if (parsedData.length === 0) {
+    return null
+  }
+
+  return (
+    <Card>
+      <CardHeader
+        title={title}
+      />
+      <CardContent style={{ padding: 0 }}>
+        <Table
+          options={{
+            search: false,
+            paging: false,
+            toolbar: false,
+            header: false,
+            padding: 'dense',
+          }}
+          data={parsedData}
+          columns={[
+            { field: 'name', highlight: true, width: '15%', cellStyle: { whiteSpace: 'nowrap' } },
+            { field: 'value' },
+          ]}
+        />
+      </CardContent>
+    </Card>
+  )
+}
+
+export const useCluster = () => (useContext(ClusterContext))
+
+export const ClusterInfoTable = () => {
+  const { data, loading, error } = useCluster();
+
+  if (error || loading) {
+    return null
+  }
+
+  const nameMap = new Map<string, string>([
+    ['name', 'Name'],
+    ['kubernetesVersion', 'Kubernetes version'],
+    ['openshiftId', 'OpenShift ID'],
+    ['openshiftVersion', 'OpenShift version'],
+    ['platform', 'Platform'],
+    ['region', 'Region'],
+    ['consoleUrl', 'Console URL'],
+    ['oauthUrl', 'OAuth URL'],
+  ])
+  return tableFromObject(data, 'Cluster Info', nameMap)
+}
+
+export const ClusterAvaliableResourceTable = (): any => {
+  const { data, loading, error } = useCluster();
+
+  if (!('availableResources' in data) || error || loading) {
+    return null
+  }
+
+  const nameMap = new Map<string, string>([
+    ['cpuCores', 'CPU cores'],
+    ['memorySize', 'Memory size'],
+    ['numberOfPods', 'Number of pods'],
+  ])
+  return tableFromObject(data.availableResources, 'Available', nameMap)
+}
+
+export const ClusterAllocatableResourceTable = (): any => {
+  const { data, loading, error } = useCluster();
+
+  if (!('allocatableResources' in data) || error || loading) {
+    return null
+  }
+
+  const nameMap = new Map<string, string>([
+    ['cpuCores', 'CPU cores'],
+    ['memorySize', 'Memory size'],
+    ['numberOfPods', 'Number of pods'],
+  ])
+  return tableFromObject(data.allocatableResources, 'Allocatable', nameMap)
+}
+
+export const ClusterStatusCard = (): any => {
+  const { data, loading, error } = useCluster();
+  let reason = data.status.reason
+
+  if (error) {
+    data.status.reason = 'Unavailable'
+  } else if (loading) {
+    /*
+    Can't do data.status.reason = 'Loading' since the value
+    will not be overwritten by the state update of the cluster (dunno why)
+    */
+    reason = 'Loading'
+  }
+
+  const down = data.status.available && data.status.reason === 'Cluster is down'
+
+  return (
+    <InfoCard title="Status" divider={false} >
+      <div style={{ textAlign: 'center', margin: 0 }}>
+        <Typography variant="h1">
+          {data.status.available ? <StatusOK />
+            : (down ? <StatusError /> : <StatusAborted />)}
+        </Typography>
+        <Typography variant="subtitle1">
+          {reason}
+        </Typography>
+      </div>
+    </InfoCard>
+  )
+}

--- a/packages/app/src/components/clusterStatusPage/ClusterStatusPage.tsx
+++ b/packages/app/src/components/clusterStatusPage/ClusterStatusPage.tsx
@@ -171,3 +171,5 @@ export const ClusterStatusPage = () => {
     </SearchContextProvider>
   );
 };
+
+export default ClusterStatusPage;

--- a/yarn.lock
+++ b/yarn.lock
@@ -6669,6 +6669,7 @@ anymatch@^3.0.3, anymatch@~3.1.2:
     "@backstage/plugin-techdocs-react" "^1.0.5"
     "@backstage/plugin-user-settings" "^0.5.0"
     "@backstage/theme" "^0.2.16"
+    "@internal/plugin-cluster-status-backend" "*"
     "@k-phoen/backstage-plugin-grafana" "^0.1.14"
     "@material-ui/core" "^4.12.2"
     "@material-ui/icons" "^4.9.1"


### PR DESCRIPTION
Part of #102 

Create a better looking cluster resource page. Data for the tables is gathered from the `cluster-status` backend plugin. Individual tables are exported as components so they can be reused elsewhere.

How it looks:

![image](https://user-images.githubusercontent.com/44006847/198104173-cdaa259d-33a5-495d-b960-1e9b32c56991.png)
