### PR TITLE
feat: Create catalog provider for ACM

### DIFF
--- a/packages/app/src/components/catalog/resource.tsx
+++ b/packages/app/src/components/catalog/resource.tsx
@@ -22,7 +22,7 @@ const resource = (
       <OverviewWrapper>
         <Grid item xs={12}>
           <EntitySwitch>
-            <EntitySwitch.Case if={isType('cluster')}>
+            <EntitySwitch.Case if={isType('kubernetes-cluster')}>
               <ClusterContextProvider>
                 <Grid container>
                   <Grid container item direction="column" xs={3}>

--- a/packages/backend/src/plugins/catalog.ts
+++ b/packages/backend/src/plugins/catalog.ts
@@ -1,5 +1,6 @@
 import { CatalogBuilder } from '@backstage/plugin-catalog-backend';
 import { ScaffolderEntitiesProcessor } from '@backstage/plugin-scaffolder-backend';
+import { ManagedClusterProvider } from '@internal/backstage-plugin-rhacm-backend';
 import { Router } from 'express';
 import { PluginEnvironment } from '../types';
 
@@ -7,8 +8,22 @@ export default async function createPlugin(
   env: PluginEnvironment,
 ): Promise<Router> {
   const builder = await CatalogBuilder.create(env);
+  const rhacm = ManagedClusterProvider.fromConfig(env.config, {
+    logger: env.logger,
+  });
   builder.addProcessor(new ScaffolderEntitiesProcessor());
+  builder.addEntityProvider(rhacm);
   const { processingEngine, router } = await builder.build();
   await processingEngine.start();
+
+  await env.scheduler.scheduleTask({
+    id: 'run_rhacm_refresh',
+    fn: async () => {
+      await rhacm.run();
+    },
+    frequency: { minutes: 30 },
+    timeout: { minutes: 10 },
+  });
+
   return router;
 }

--- a/packages/backend/src/plugins/catalog.ts
+++ b/packages/backend/src/plugins/catalog.ts
@@ -1,8 +1,44 @@
-import { CatalogBuilder } from '@backstage/plugin-catalog-backend';
+import { Entity, ResourceEntity } from '@backstage/catalog-model';
+import {
+  CatalogBuilder,
+  CatalogProcessor,
+  CatalogProcessorCache,
+  CatalogProcessorEmit,
+} from '@backstage/plugin-catalog-backend';
+import { LocationSpec } from '@backstage/plugin-catalog-common';
 import { ScaffolderEntitiesProcessor } from '@backstage/plugin-scaffolder-backend';
 import { ManagedClusterProvider } from '@internal/backstage-plugin-rhacm-backend';
 import { Router } from 'express';
 import { PluginEnvironment } from '../types';
+
+class OpenshiftResourceProcessor implements CatalogProcessor {
+  getProcessorName(): string {
+    return 'OpenshiftResourceProcessor';
+  }
+
+  async preProcessEntity(
+    entity: Entity,
+    _location: LocationSpec,
+    _emit: CatalogProcessorEmit,
+    originLocation: LocationSpec,
+    _cache: CatalogProcessorCache,
+  ): Promise<Entity> {
+    if (entity.kind !== 'Resource') {
+      return entity;
+    }
+    const resource = entity as ResourceEntity;
+    if (resource.spec.type !== 'kubernetes-cluster') {
+      return resource;
+    }
+
+    if (originLocation.type === 'rhacm-managed-cluster') {
+      resource.metadata.annotations ||= {};
+      resource.metadata.annotations['operate-first.cloud/logo-url'] =
+        'https://upload.wikimedia.org/wikipedia/commons/3/3a/OpenShift-LogoType.svg';
+    }
+    return resource;
+  }
+}
 
 export default async function createPlugin(
   env: PluginEnvironment,
@@ -13,6 +49,7 @@ export default async function createPlugin(
   });
   builder.addProcessor(new ScaffolderEntitiesProcessor());
   builder.addEntityProvider(rhacm);
+  builder.addProcessor(new OpenshiftResourceProcessor());
   const { processingEngine, router } = await builder.build();
   await processingEngine.start();
 

--- a/plugins/rhacm-backend/src/index.ts
+++ b/plugins/rhacm-backend/src/index.ts
@@ -15,3 +15,4 @@
  */
 
 export * from './service/router';
+export * from './providers';

--- a/plugins/rhacm-backend/src/providers/ManagedClusterProvider.ts
+++ b/plugins/rhacm-backend/src/providers/ManagedClusterProvider.ts
@@ -1,0 +1,115 @@
+/*
+ * Copyright 2021 Larder Software Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { ResourceEntity } from '@backstage/catalog-model';
+import * as winston from 'winston';
+import { Config } from '@backstage/config';
+import {
+  EntityProvider,
+  EntityProviderConnection,
+} from '@backstage/plugin-catalog-node';
+import {
+  ANNOTATION_ORIGIN_LOCATION,
+  ANNOTATION_LOCATION,
+} from '@backstage/catalog-model'
+import { CustomObjectsApi } from "@kubernetes/client-node"
+import { getManagedCluster, getManagedClusters, hubApiClient } from '../helpers/kubernetes';
+import { CONSOLE_CLAIM, HUB_CLUSTER_NAME_IN_ACM } from '../constants';
+import { getClaim } from '../helpers/parser';
+import { getHubClusterName } from '../helpers/config';
+
+/**
+ * Provides entities from AWS EKS Cluster service.
+ */
+export class ManagedClusterProvider implements EntityProvider {
+  protected readonly client: CustomObjectsApi;
+  protected readonly hubName: string;
+  protected readonly logger: winston.Logger;
+  protected connection?: EntityProviderConnection;
+
+  protected constructor(client: CustomObjectsApi, hubName: string, options: { logger: winston.Logger }) {
+    this.client = client;
+    this.hubName = hubName;
+    this.logger = options.logger;
+  }
+
+  static fromConfig(config: Config, options: { logger: winston.Logger }) {
+    const client = hubApiClient(config, options.logger);
+    const hubName = getHubClusterName(config);
+
+    return new ManagedClusterProvider(client, hubName, options);
+  }
+  public async connect(connection: EntityProviderConnection): Promise<void> {
+    this.connection = connection;
+  }
+
+  getProviderName(): string {
+    return 'rhacm-managed-cluster';
+  }
+
+  async run(): Promise<void> {
+    if (!this.connection) {
+      throw new Error('Not initialized');
+    }
+
+    this.logger.info(
+      `Providing OpenShift cluster resources from RHACM`,
+    );
+    const hubConsole = getClaim(await getManagedCluster(this.client, HUB_CLUSTER_NAME_IN_ACM), CONSOLE_CLAIM)
+
+    const resources: ResourceEntity[] = (await getManagedClusters(this.client) as {items: Array<any>}).items.map((i) => {
+      return {
+        kind: 'Resource',
+        apiVersion: 'backstage.io/v1beta1',
+        metadata: {
+          name: i.metadata.name,
+          title: i.metadata?.labels?.name,
+          annotations: {
+            [ANNOTATION_LOCATION]: `${this.getProviderName()}:${this.hubName}`,
+            [ANNOTATION_ORIGIN_LOCATION]: `${this.getProviderName()}:${this.hubName}`,
+          },
+          links: [
+            {
+              url: getClaim(i, CONSOLE_CLAIM),
+              title: "OpenShift Console",
+              icon: "dashboard"
+            },
+            {
+              url: `${hubConsole}/multicloud/infrastructure/clusters/details/${i.metadata.name}/`,
+              title: "RHACM Console",
+            },
+            i.metadata?.labels?.clusterID && {
+              url: `https://console.redhat.com/openshift/details/s/${i.metadata.labels.clusterID}`,
+              title: 'OpenShift Cluster Manager',
+            }
+          ]
+        },
+        spec: {
+          owner: 'unknown',
+          type: 'kubernetes-cluster',
+        },
+      };
+    })
+
+    await this.connection.applyMutation({
+      type: 'full',
+      entities: resources.map(entity => ({
+        entity,
+        locationKey: 'rhacm-managed-cluster',
+      })),
+    });
+  }
+}

--- a/plugins/rhacm-backend/src/providers/ManagedClusterProvider.ts
+++ b/plugins/rhacm-backend/src/providers/ManagedClusterProvider.ts
@@ -32,7 +32,7 @@ import { getClaim } from '../helpers/parser';
 import { getHubClusterName } from '../helpers/config';
 
 /**
- * Provides entities from AWS EKS Cluster service.
+ * Provides OpenShift cluster resource entities from RHACM.
  */
 export class ManagedClusterProvider implements EntityProvider {
   protected readonly client: CustomObjectsApi;

--- a/plugins/rhacm-backend/src/providers/index.ts
+++ b/plugins/rhacm-backend/src/providers/index.ts
@@ -1,0 +1,1 @@
+export { ManagedClusterProvider } from './ManagedClusterProvider';


### PR DESCRIPTION
Create an automated catalog provider for Managed Clusters resources.

1. https://github.com/operate-first/service-catalog/commit/276065f841f38141e361882e833be67e0cf63d9f commit:
   - Creates a `ManagedClusterProvider` which populates `Resource` catalog entity based on ACMs data.
   - Resources are set to type of `kubernetes-cluster` in preparation for [`CatalogClusterLocator`](https://github.com/backstage/backstage/blob/master/plugins/kubernetes-backend/src/cluster-locator/CatalogClusterLocator.ts#L43) from `backstage/kubernetes` plugin.
   - Automatically populate links to OCP console, RHACM console and console.redhat.com.
2. https://github.com/operate-first/service-catalog/commit/39f8a70444e010df64e224e46d0d264530f33fbd commit:
   - Creates a custom pre-processor catching all clusters created by the `ManagedClusterProvider` and enriches it downstream with `operate-first.cloud/logo-url` annotation.

This PR disregards whether the cluster is or is not configured in `backstage/kubernetes` plugin settings. Right now we care about the cluster status only. Integration with `backstage/kubernetes` can come in the future.