### PR TITLE
feat: Create Kubernetes Pod status overview card

### DIFF
--- a/packages/app/src/components/DeploymentStatusCard/DeploymentStatusCard.tsx
+++ b/packages/app/src/components/DeploymentStatusCard/DeploymentStatusCard.tsx
@@ -1,0 +1,118 @@
+import {
+  Progress,
+  StatusAborted,
+  StatusError,
+  StatusOK,
+  StatusPending,
+  StatusWarning,
+} from '@backstage/core-components';
+import { useEntity } from '@backstage/plugin-catalog-react';
+import {
+  detectErrors,
+  useKubernetesObjects,
+} from '@backstage/plugin-kubernetes';
+import { Typography } from '@material-ui/core';
+import React, { useEffect, useState } from 'react';
+import StatusCard from '../catalog/shared/StatusCard';
+
+type Phase = {
+  running: number;
+  pending: number;
+  succeeded: number;
+  failed: number;
+  unknown: number;
+  hasError: number;
+};
+
+const Status = ({ pods }: { pods: Phase }) => {
+  if (pods.failed) {
+    return <StatusError />;
+  }
+  if (pods.hasError) {
+    return <StatusWarning />;
+  }
+  if (pods.pending) {
+    return <StatusPending />;
+  }
+  if (pods.running) {
+    return <StatusOK />;
+  }
+  return <StatusAborted />;
+};
+
+const DeploymentStatusCard = () => {
+  const { entity } = useEntity();
+  const [pods, setPods] = useState({} as Phase);
+
+  const { kubernetesObjects, error } = useKubernetesObjects(entity, 30000);
+
+  useEffect(() => {
+    if (!kubernetesObjects || kubernetesObjects?.items.length === 0) {
+      return;
+    }
+
+    const newPods = kubernetesObjects.items
+      .flatMap(item =>
+        item.resources
+          .filter(resource => resource.type === 'pods')
+          .flatMap(resource => resource.resources),
+      )
+      .reduce((acc, v) => {
+        const phase = (v.status.phase as string).toLowerCase();
+        return {
+          ...acc,
+          [phase]: acc[phase] + 1,
+        };
+      }, new Proxy({} as Phase, { get: (t, n) => (t.hasOwnProperty(n) ? (t as any)[n] : 0) }));
+
+    newPods.hasError = new Set(
+      kubernetesObjects.items
+        .flatMap(item =>
+          detectErrors(kubernetesObjects).get(item.cluster.name),
+        )
+        ?.filter(de => de?.kind === 'Pod')
+        .map(de => de?.names)
+        .flat() ?? [],
+    ).size;
+
+    setPods(newPods);
+  }, [kubernetesObjects, error]);
+
+  const pluralizeBe = (count: number) => (count === 1 ? ' is' : 's are');
+  const pluralizeHave = (count: number) => (count === 1 ? ' has' : 's have');
+
+  return (
+    <StatusCard
+      title="Deployment"
+      deepLink={{ title: 'View more', link: 'kubernetes' }}
+    >
+      {kubernetesObjects === undefined ? (
+        <Progress />
+      ) : (
+        <>
+          <Typography variant="h1" component="div">
+            <Status pods={pods} />
+          </Typography>
+          <Typography variant="subtitle2" component="div">
+            {pods.running
+              ? `${pods.running} pod${pluralizeBe(pods.running)} running`
+              : 'No pods running'}
+          </Typography>
+          {pods.running > 0 || pods.pending > 0 && (
+            <Typography variant="subtitle2" component="div">
+              ({pods.hasError || 0} pod{pluralizeBe(pods.hasError)} reporting
+              errors)
+            </Typography>
+          )}
+          {pods.failed > 0 && (
+            <Typography variant="subtitle2" component="div">
+              ({pods.failed} pod{pluralizeHave(pods.failed)} failed)
+            </Typography>
+          )}
+        </>
+      )}
+    </StatusCard>
+  );
+};
+
+export default DeploymentStatusCard;

--- a/packages/app/src/components/catalog/component.tsx
+++ b/packages/app/src/components/catalog/component.tsx
@@ -38,6 +38,8 @@ import { HorizontalScrollGrid, StatusOK } from '@backstage/core-components';
 import StatusCard from './shared/StatusCard';
 import { isType } from './shared/utils';
 
+import DeploymentStatusCard from '../DeploymentStatusCard/DeploymentStatusCard';
+
 const component = (
   <LayoutWrapper>
     <EntityLayout.Route path="/" title="Overview">
@@ -76,17 +78,7 @@ const component = (
             </StatusCard>
             <EntitySwitch>
               <EntitySwitch.Case if={isType(['service', 'operator'])}>
-                <StatusCard
-                  title="Deployment"
-                  deepLink={{ title: 'View more', link: 'kubernetes' }}
-                >
-                  <Typography variant="h1" component="div">
-                    <StatusOK />
-                  </Typography>
-                  <Typography variant="subtitle2" component="div">
-                    1 deployment ready, no errors
-                  </Typography>
-                </StatusCard>
+                <DeploymentStatusCard />
                 <StatusCard
                   title="Alerts"
                   deepLink={{ title: 'View more', link: 'kubernetes' }}


### PR DESCRIPTION
Populate the "Deployments" status card with data:

### No pods
![2022-11-01_16-29_1](https://user-images.githubusercontent.com/7453394/199275892-297d8ac4-54d4-4fdf-8e81-509da3f004b9.png)
### Loading state
![2022-11-01_16-29_2](https://user-images.githubusercontent.com/7453394/199275915-bfd5cbbe-0390-4b98-8c67-dbd619d4a811.png)
### All OK
![2022-11-01_16-29](https://user-images.githubusercontent.com/7453394/199275931-6d220e58-4428-4038-89ba-0666ebb7d072.png)
### Errors found in running pods
![2022-11-01_16-30](https://user-images.githubusercontent.com/7453394/199278819-09eedd4d-ead3-42eb-8bd8-d67eff1d9a20.png)
### Pod has failed during scheduling
e.g. image pull error - state of the pod is `Pending` and pod is reporting errors
![2022-11-01_16-53](https://user-images.githubusercontent.com/7453394/199279173-981250de-11e3-434f-8b79-8f1525d6a155.png)
### Pods have failed
![2022-11-01_16-56](https://user-images.githubusercontent.com/7453394/199278659-d3762890-a912-49fc-a8bb-4a0d4ebb5dcd.png)



Replaces the placeholder status card with a proper one.