### PR TITLE
feat: Add support for mermaid diagrams in techdocs

### DIFF
--- a/.github/workflows/techdocs-generate-and-publish.yaml
+++ b/.github/workflows/techdocs-generate-and-publish.yaml
@@ -46,7 +46,7 @@ jobs:
         run: sudo npm install --location=global @techdocs/cli
 
       - name: Install mkdocs and mkdocs plugins
-        run: python -m pip install mkdocs-techdocs-core==1.*
+        run: python -m pip install mkdocs-techdocs-core==1.* mkdocs-kroki-plugin
 
       - name: Generate docs site
         working-directory: ${{ github.event.client_payload.docs_path }}

--- a/mkdocs.yaml
+++ b/mkdocs.yaml
@@ -10,3 +10,4 @@ nav:
 plugins:
   - techdocs-core
   - search
+  - kroki


### PR DESCRIPTION
Part of #71 

Add support for mermaid diagrams into techdocs via [kroki](https://kroki.io/) which supports many more diagrams, see [upstream docs](https://backstage.io/docs/features/techdocs/how-to-guides#how-to-add-mermaid-support-in-techdocs).

