### PR TITLE
fix: Change HTTP probe to exec

### DIFF
--- a/manifests/base/deployment.yaml
+++ b/manifests/base/deployment.yaml
@@ -64,15 +64,17 @@ spec:
             requests:
               cpu: 200m
           livenessProbe:
-            httpGet:
-              path: /healthz
-              port: 7007
+            exec:
+              command:
+                - curl
+                - http://localhost:7007/healthz
             failureThreshold: 1
             periodSeconds: 10
           startupProbe:
-            httpGet:
-              path: /healthz
-              port: 7007
+            exec:
+              command:
+                - curl
+                - http://localhost:7007/healthz
             failureThreshold: 30
             periodSeconds: 10
       volumes:


### PR DESCRIPTION
Part of #171 

This workaround might fix the issue see https://github.com/operate-first/service-catalog/issues/171#issuecomment-1305297972.