### PR TITLE
fix: Increase timeout for probes

### DIFF
--- a/manifests/base/deployment.yaml
+++ b/manifests/base/deployment.yaml
@@ -64,19 +64,19 @@ spec:
             requests:
               cpu: 200m
           livenessProbe:
-            exec:
-              command:
-                - curl
-                - http://localhost:7007/healthz
+            httpGet:
+              path: /healthz
+              port: 7007
             failureThreshold: 1
             periodSeconds: 10
+            timeoutSeconds: 5
           startupProbe:
-            exec:
-              command:
-                - curl
-                - http://localhost:7007/healthz
+            httpGet:
+              path: /healthz
+              port: 7007
             failureThreshold: 30
             periodSeconds: 10
+            timeoutSeconds: 5
       volumes:
         - name: ca-cert
           secret:


### PR DESCRIPTION
Part of #171 

Add a longer timeout to the HTTP requests. I tested this out and it worked for 10+ hours in prod environment. Also change back to HTTP probe since the exec probe didn't solve the problem.