### PR TITLE
chore: Remove secret from base deployment

### DIFF
--- a/manifests/base/kustomization.yaml
+++ b/manifests/base/kustomization.yaml
@@ -5,7 +5,6 @@ resources:
   - deployment.yaml
   - service.yaml
   - route.yaml
-  - secret.yaml
   - postgres.yaml
   - serviceaccount.yaml
 commonLabels:

--- a/manifests/base/secret.yaml
+++ b/manifests/base/secret.yaml
@@ -1,4 +1,0 @@
-apiVersion: v1
-kind: Secret
-metadata:
-  name: service-catalog


### PR DESCRIPTION
Argocd is complaining about the secret located in this repository base manifests since the secret is getting created via an external secret.
Warning text:
```
Secret/service-catalog is part of applications service-catalog-smaug and cluster-resources-smaug
```