### PR TITLE
fix: Raise proper error when hub cluster is undefined in the config

### DIFF
--- a/plugins/rhacm-backend/src/helpers/config.ts
+++ b/plugins/rhacm-backend/src/helpers/config.ts
@@ -13,6 +13,12 @@ export const getClustersFromConfig = (config: Config): Config[] => {
 };
 
 export const getHubClusterFromConfig = (config: Config) => {
+  try {
+    config.getString(HUB_CLUSTER_CONFIG_PATH)
+  } catch (err) {
+    throw new Error(`Hub cluster must be specified in config at '${HUB_CLUSTER_CONFIG_PATH}'`);
+  }
+
   const hub = config
     .getConfigArray(CLUSTERS_PATH)
     .flatMap(method => method.getOptionalConfigArray('clusters') || [])


### PR DESCRIPTION
Rather than raising a generic config error about `rhacm.hub` not being found in config, display more specific message in the logs.