### PR TITLE
feat: Create LinkTiles component

### DIFF
--- a/packages/app/src/components/LinkTiles/LinkTile.tsx
+++ b/packages/app/src/components/LinkTiles/LinkTile.tsx
@@ -1,0 +1,56 @@
+import React from 'react';
+import { EntityLink } from '@backstage/catalog-model';
+import { Link } from '@backstage/core-components';
+import { useApp } from '@backstage/core-plugin-api';
+import { BackstageTheme } from '@backstage/theme';
+import { Box, createStyles, makeStyles, Typography } from '@material-ui/core';
+import LanguageIcon from '@material-ui/icons/Language';
+import ArrowRightIcon from '@material-ui/icons/ArrowForwardIos';
+
+const useStyles = makeStyles((theme: BackstageTheme) =>
+  createStyles({
+    card: {
+      border: `1px solid ${theme.palette.divider}`,
+      boxShadow: theme.shadows[2],
+      borderRadius: '4px',
+      gap: '1em',
+      padding: theme.spacing(2),
+      color: '#fff',
+      transition: `${theme.transitions.duration.standard}ms`,
+      '&:hover': {
+        boxShadow: theme.shadows[4],
+      },
+      background: theme.page.backgroundImage,
+    },
+    link: {
+      '&:hover': {
+        textDecoration: 'none',
+      }
+    }
+  }),
+);
+
+const LinkTile = ({url, title, icon }: EntityLink) => {
+  const classes = useStyles();
+  const app = useApp();
+
+  const Icon = icon ? app.getSystemIcon(icon) ?? LanguageIcon : LanguageIcon;
+
+  return (
+    <Link to={url} variant="body2" className={classes.link}>
+      <Box
+        className={classes.card}
+        display="flex"
+        alignItems="center"
+      >
+        <Icon />
+        <Typography variant="h6">
+          {title}
+        </Typography>
+        <ArrowRightIcon />
+      </Box>
+    </Link>
+  )
+}
+
+export default LinkTile;

--- a/packages/app/src/components/LinkTiles/LinkTiles.tsx
+++ b/packages/app/src/components/LinkTiles/LinkTiles.tsx
@@ -1,0 +1,22 @@
+import { HorizontalScrollGrid } from '@backstage/core-components';
+import { useEntity } from '@backstage/plugin-catalog-react';
+import { Grid } from '@material-ui/core';
+import React from 'react';
+import LinkTile from './LinkTile';
+
+const LinkTiles = () => {
+  const { entity } = useEntity();
+
+  if (!entity.metadata.links) {
+    return null;
+  }
+
+  return (
+    <HorizontalScrollGrid>
+      { entity.metadata.links.map(l => <Grid item><LinkTile {...l}/></Grid>) }
+    </HorizontalScrollGrid>
+  )
+
+}
+
+export default LinkTiles;

--- a/packages/app/src/components/catalog/component.tsx
+++ b/packages/app/src/components/catalog/component.tsx
@@ -36,9 +36,10 @@ import { EntityKubernetesContent } from '@backstage/plugin-kubernetes';
 import OverviewWrapper from './shared/OverviewWrapper';
 import { HorizontalScrollGrid, StatusOK } from '@backstage/core-components';
 import StatusCard from './shared/StatusCard';
-import { isType } from './shared/utils';
+import { hasLinks, isType } from './shared/utils';
 
 import DeploymentStatusCard from '../DeploymentStatusCard/DeploymentStatusCard';
+import LinkTiles from '../LinkTiles/LinkTiles';
 
 const component = (
   <LayoutWrapper>
@@ -100,6 +101,21 @@ const component = (
             </div>
           </HorizontalScrollGrid>
         </Grid>
+        <EntitySwitch>
+          <EntitySwitch.Case if={hasLinks}>
+            <Grid item xs={12}>
+              <Typography variant="h4" component="h2">
+                Quick actions
+              </Typography>
+              <Typography variant="body1">
+                Self service, quick access and links to learn more about this component
+              </Typography>
+            </Grid>
+            <Grid item xs={12}>
+              <LinkTiles />
+            </Grid>
+          </EntitySwitch.Case>
+        </EntitySwitch>
       </OverviewWrapper>
     </EntityLayout.Route>
 

--- a/packages/app/src/components/catalog/domain.tsx
+++ b/packages/app/src/components/catalog/domain.tsx
@@ -1,17 +1,26 @@
 import React from 'react';
 import { Grid } from '@material-ui/core';
-import { EntityHasSystemsCard, EntityLayout } from '@backstage/plugin-catalog';
+import { EntityHasSystemsCard, EntityLayout, EntitySwitch } from '@backstage/plugin-catalog';
 import LayoutWrapper from './shared/LayoutWrapper';
 import {
   Direction,
   EntityCatalogGraphCard,
 } from '@backstage/plugin-catalog-graph';
 import OverviewWrapper from './shared/OverviewWrapper';
+import { hasLinks } from './shared/utils';
+import LinkTiles from '../LinkTiles/LinkTiles';
 
 const domain = (
   <LayoutWrapper>
     <EntityLayout.Route path="/" title="Overview">
       <OverviewWrapper>
+        <EntitySwitch>
+          <EntitySwitch.Case if={hasLinks}>
+            <Grid item xs={12}>
+              <LinkTiles />
+            </Grid>
+          </EntitySwitch.Case>
+        </EntitySwitch>
         <Grid item xs={12}>
           <EntityCatalogGraphCard
             variant="gridItem"

--- a/packages/app/src/components/catalog/resource.tsx
+++ b/packages/app/src/components/catalog/resource.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
-import { Grid } from '@material-ui/core';
+import { Grid, Typography } from '@material-ui/core';
 import { EntityLayout, EntitySwitch } from '@backstage/plugin-catalog';
 import LayoutWrapper from './shared/LayoutWrapper';
-import { isType } from './shared/utils';
+import { hasLinks, isType } from './shared/utils';
 import {
   EntityTechdocsContent,
   isTechDocsAvailable,
@@ -15,6 +15,7 @@ import {
   ClusterContextProvider,
   ClusterStatusCard
 } from '@internal/backstage-plugin-rhacm';
+import LinkTiles from '../LinkTiles/LinkTiles';
 
 const resource = (
   <LayoutWrapper>
@@ -44,6 +45,21 @@ const resource = (
             </EntitySwitch.Case>
           </EntitySwitch>
         </Grid>
+        <EntitySwitch>
+          <EntitySwitch.Case if={hasLinks}>
+            <Grid item xs={12}>
+              <Typography variant="h4" component="h2">
+                Quick actions
+              </Typography>
+              <Typography variant="body1">
+                Self service, quick access and links to learn more about this resource
+              </Typography>
+            </Grid>
+            <Grid item xs={12}>
+              <LinkTiles />
+            </Grid>
+          </EntitySwitch.Case>
+        </EntitySwitch>
       </OverviewWrapper>
     </EntityLayout.Route>
 

--- a/packages/app/src/components/catalog/shared/OverviewWrapper.tsx
+++ b/packages/app/src/components/catalog/shared/OverviewWrapper.tsx
@@ -1,8 +1,6 @@
 import React from 'react';
 import { Grid } from '@material-ui/core';
-import { EntityLinksCard, EntitySwitch } from '@backstage/plugin-catalog';
 import Warning from './Warning';
-import { hasLinks } from './utils';
 import InfoCard from './InfoCard';
 
 const OverviewWrapper = ({ children }: { children?: React.ReactNode }) => (
@@ -14,13 +12,6 @@ const OverviewWrapper = ({ children }: { children?: React.ReactNode }) => (
     <Grid item xs={12} md={3} container spacing={3} alignItems="stretch">
       <Grid item xs={12}>
         <InfoCard />
-      </Grid>
-      <Grid item xs={12}>
-        <EntitySwitch>
-          <EntitySwitch.Case if={hasLinks}>
-            <EntityLinksCard cols={1} />
-          </EntitySwitch.Case>
-        </EntitySwitch>
       </Grid>
     </Grid>
   </Grid>

--- a/packages/app/src/components/catalog/system.tsx
+++ b/packages/app/src/components/catalog/system.tsx
@@ -16,11 +16,20 @@ import LayoutWrapper from './shared/LayoutWrapper';
 import OverviewWrapper from './shared/OverviewWrapper';
 import { EntityKubernetesContent, isKubernetesAvailable } from '@backstage/plugin-kubernetes';
 import { EntityArgoCDOverviewCard, isArgocdAvailable } from '@roadiehq/backstage-plugin-argo-cd';
+import { hasLinks } from './shared/utils';
+import LinkTiles from '../LinkTiles/LinkTiles';
 
 const system = (
   <LayoutWrapper>
     <EntityLayout.Route path="/" title="Overview">
       <OverviewWrapper>
+        <EntitySwitch>
+          <EntitySwitch.Case if={hasLinks}>
+            <Grid item xs={12}>
+              <LinkTiles />
+            </Grid>
+          </EntitySwitch.Case>
+        </EntitySwitch>
         <Grid item xs={12}>
           <EntityCatalogGraphCard
             variant="gridItem"


### PR DESCRIPTION
Resolves: https://github.com/operate-first/service-catalog/issues/183

Instead of a boring `EntityLinksCard`

![image](https://user-images.githubusercontent.com/7453394/200905707-b82d2d5e-3d02-4543-a5a7-0827697184bc.png)


Let's show something more interesting - `LinkTiles`:

![image](https://user-images.githubusercontent.com/7453394/200906018-cafda701-b73d-4397-8276-b15131724b43.png)


It respects the entity page theme, so `Components` are displayed in different color than `Resources` etc.

We maintain the same logic for icon fetching as the `EntityLinksCard` so there should be no confusion.