### PR TITLE
feat(SRE-portal): Update UI to support cluster and token input

### DIFF
--- a/app-config.local.yaml
+++ b/app-config.local.yaml
@@ -47,6 +47,9 @@ kubernetes:
           # dashboardUrl: <dashboard_url>
           # dashboardApp: <dashboard_type>  # Supported dashboards: standard, rancher, openshift, gke, aks, eks
 
+webTerminal:
+  webSocketUrl: "wss://example.com:3000"
+
 rhacm:
   hub: 'dev-cluster'
 

--- a/plugins/web-terminal/package.json
+++ b/plugins/web-terminal/package.json
@@ -22,6 +22,7 @@
     "prepack": "backstage-cli package prepack",
     "postpack": "backstage-cli package postpack"
   },
+  "configSchema": "schema.d.ts",
   "dependencies": {
     "@backstage/core-components": "^0.12.0",
     "@backstage/core-plugin-api": "^1.1.0",
@@ -31,6 +32,7 @@
     "@material-ui/lab": "^4.0.0-alpha.45",
     "react-use": "^17.2.4",
     "xterm": "^5.0.0",
+    "xterm-addon-attach": "^0.7.0",
     "xterm-addon-fit": "^0.6.0"
   },
   "peerDependencies": {
@@ -49,6 +51,7 @@
     "msw": "^0.47.0"
   },
   "files": [
-    "dist"
+    "dist",
+    "schema.d.ts"
   ]
 }

--- a/plugins/web-terminal/schema.d.ts
+++ b/plugins/web-terminal/schema.d.ts
@@ -1,0 +1,11 @@
+export interface Config {
+  /** webTerminal webSocketServer configuration */
+  webTerminal: {
+    /**
+     * The URL of the webSocketServer
+     *
+     * @visibility frontend
+     */
+    webSocketUrl: string;
+  };
+}

--- a/plugins/web-terminal/src/components/TerminalComponent/TerminalComponent.tsx
+++ b/plugins/web-terminal/src/components/TerminalComponent/TerminalComponent.tsx
@@ -1,27 +1,117 @@
-import { makeStyles } from '@material-ui/core';
-import React from 'react';
+import { Button, makeStyles, TextField } from '@material-ui/core';
+import React, { useCallback } from 'react';
 import { Terminal } from 'xterm';
 import { FitAddon } from 'xterm-addon-fit';
+import { AttachAddon } from 'xterm-addon-attach';
+import { InfoCard, Progress } from '@backstage/core-components';
+import { useApi, configApiRef } from '@backstage/core-plugin-api';
+
 import './static/xterm.css';
 
 const useTerminalStyles = makeStyles({
   term: {
     width: '100%',
-    height: '100%',
+    height: '400px',
+  },
+  formDisplay: {
+    display: 'flex',
+    justifyContent: 'center',
+    alignItems: 'center',
+    flexDirection: 'column',
+    rowGap: '10px',
+    margin: '10px',
+  },
+  centerInfo: {
+    textAlign: 'center',
+    marginTop: '10px',
+    marginBottom: '10px',
   },
 });
+
+interface IFormData {
+  token: string | undefined;
+  cluster: string | undefined;
+}
+
 export const TerminalComponent = () => {
-  const fitAddon = new FitAddon();
-  const terminal = new Terminal();
-  terminal.loadAddon(fitAddon);
-  fitAddon.fit();
-  const classes = useTerminalStyles();
-  React.useEffect(() => {
-    const terminalElement = document.getElementById('terminal');
-    if (terminalElement) {
-      terminal.open(terminalElement);
-      terminal.write('$ ');
-    }
+  const [websocketRunning, setWebsocketRunning] = React.useState(false);
+  const [loading, setLoading] = React.useState(false);
+  const [formData, setFormData] = React.useState<IFormData>({
+    token: undefined,
+    cluster: undefined,
   });
-  return <div className={classes.term} id="terminal" />;
+  const classes = useTerminalStyles();
+  const tokenRef = React.useRef<HTMLInputElement>(null);
+  const clusterRef = React.useRef<HTMLInputElement>(null);
+  const termRef = React.useRef(null);
+  const config = useApi(configApiRef);
+  const webSocketUrl = config.getString('webTerminal.webSocketUrl');
+  /**
+   * Terminal is attached to created websocket, attachment allows user
+   * to interact with terminal as they would with a normal terminal
+   */
+  const setupTerminal = useCallback((ws: WebSocket) => {
+    const terminal = new Terminal();
+    terminal.loadAddon(new AttachAddon(ws));
+    const fitAddon = new FitAddon();
+    terminal.loadAddon(fitAddon);
+    fitAddon.fit();
+    if (termRef.current) {
+      terminal.open(termRef.current);
+    }
+  }, []);
+
+  const handleSubmit = (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    setFormData({
+      token: tokenRef.current?.value,
+      cluster: clusterRef.current?.value,
+    });
+  };
+
+  React.useEffect(() => {
+    if (!formData.token || !formData.cluster) {
+      return;
+    }
+    setLoading(true);
+    const ws = new WebSocket(webSocketUrl, [
+      `base64url.bearer.authorization.k8s.io.${encodeURIComponent(
+        formData.token,
+      )}`,
+      `base64url.console.link.k8s.io.${encodeURIComponent(formData.cluster)}`,
+    ]);
+    ws.onopen = () => {
+      setLoading(false);
+      setWebsocketRunning(true);
+      setupTerminal(ws);
+    };
+    ws.onclose = () => {};
+  }, [formData, setupTerminal]);
+
+  if (loading) {
+    return <Progress />;
+  }
+
+  if (websocketRunning) {
+    return <div className={classes.term} ref={termRef} />;
+  }
+
+  return (
+    <div>
+      <InfoCard title="Web Terminal" noPadding>
+        <form onSubmit={handleSubmit} className={classes.formDisplay}>
+          <TextField label="Cluster" variant="outlined" inputRef={clusterRef} />
+          <TextField
+            label="Token"
+            type="password"
+            variant="outlined"
+            inputRef={tokenRef}
+          />
+          <Button type="submit" color="primary" variant="contained">
+            Submit
+          </Button>
+        </form>
+      </InfoCard>
+    </div>
+  );
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -21198,6 +21198,11 @@ xtend@^4.0.0, xtend@~4.0.1:
   resolved "https://registry.yarnpkg.com/xtend/-/xtend-4.0.2.tgz#bb72779f5fa465186b1f438f674fa347fdb5db54"
   integrity sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==
 
+xterm-addon-attach@^0.7.0:
+  version "0.7.0"
+  resolved "https://registry.yarnpkg.com/xterm-addon-attach/-/xterm-addon-attach-0.7.0.tgz#6775b3c5f1e9f91ae4cd9089f5ecb49fda8d2946"
+  integrity sha512-Yh3Kvq2e28onjnmGizQKZwlRMp9gmuZEHVX0BVZbo463YSjkqfhQS3T2wMLuO+j8AokccXsMa1z0bH1/+MMYuQ==
+
 xterm-addon-fit@^0.6.0:
   version "0.6.0"
   resolved "https://registry.yarnpkg.com/xterm-addon-fit/-/xterm-addon-fit-0.6.0.tgz#142e1ce181da48763668332593fc440349c88c34"


### PR DESCRIPTION
This PR updates UI and add logic to handle token and cluster submission for the terminal. It uses subprotocols to transfer inputed data to websocket server for now is just dummy. On the Websocket server side it is expected that it will parse subprotocols and extract data from it. Cluster is inputed in a format `api.my.cluster.com:6443`
![image](https://user-images.githubusercontent.com/47832967/206383856-3b13d986-0ec8-4616-9d53-8ebfa808d53f.png)
![image](https://user-images.githubusercontent.com/47832967/206384066-ec49dbdb-0188-4d9d-a25b-8a51d2d57ac8.png)
To actually display some data it needs running Websocket server without the server it will stay in loading state.