### PR TITLE
fix: Fix build with webterminal internal plugin

### DIFF
--- a/plugins/web-terminal/schema.d.ts
+++ b/plugins/web-terminal/schema.d.ts
@@ -1,6 +1,7 @@
 export interface Config {
   /** webTerminal webSocketServer configuration */
-  webTerminal: {
+  webTerminal?: {
+    // FIXME: changing this to optional because it break the build when included as an internal plugin
     /**
      * The URL of the webSocketServer
      *


### PR DESCRIPTION
Mandatory config of the plugin causes runtime issues in prod since it's not configured but included for some reason (even though the plugin is not actually installed in the instance):

```
Backend failed to start up Error: Invalid app bundle schema. If this error is unexpected you need to run `yarn build` in the app. If that doesn't help you should make sure your config schema is correct and rebuild the app bundle again. Caused by the following schema error, Error: Config validation failed, Config must have required property 'webTerminal' { missingProperty=webTerminal } at
    at readConfigs (/opt/app-root/src/node_modules/@backstage/plugin-app-backend/dist/index.cjs.js:69:13)
    at async Object.createRouter (/opt/app-root/src/node_modules/@backstage/plugin-app-backend/dist/index.cjs.js:225:24)
    at async createPlugin$a (/opt/app-root/src/packages/backend/dist/index.cjs.js:90:10)
    at async main (/opt/app-root/src/packages/backend/dist/index.cjs.js:381:208)
```