### PR TITLE
feat (SRE-portal): Client setup for webterminal

### DIFF
--- a/plugins/web-terminal/src/components/TerminalComponent/utils/index.ts
+++ b/plugins/web-terminal/src/components/TerminalComponent/utils/index.ts
@@ -1,0 +1,1 @@
+export { createWorkspace, getWorkspace } from './requests';

--- a/plugins/web-terminal/src/components/TerminalComponent/utils/requests.ts
+++ b/plugins/web-terminal/src/components/TerminalComponent/utils/requests.ts
@@ -1,0 +1,74 @@
+const NAMESPACE = 'openshift-terminal';
+const WORKSPACE_ENDPOINT = `apis/workspace.devfile.io/v1alpha2/namespaces/${NAMESPACE}/devworkspaces`;
+
+const workspace = {
+  apiVersion: 'workspace.devfile.io/v1alpha2',
+  kind: 'DevWorkspace',
+  metadata: {
+    generateName: 'web-terminal-',
+    namespace: NAMESPACE,
+    labels: {
+      'console.openshift.io/terminal': 'true',
+    },
+    annotations: {
+      'controller.devfile.io/restricted-access': 'true',
+      'controller.devfile.io/devworkspace-source': 'web-terminal',
+    },
+  },
+  spec: {
+    started: true,
+    routingClass: 'web-terminal',
+    template: {
+      components: [
+        {
+          name: 'web-terminal-tooling',
+          plugin: {
+            kubernetes: {
+              name: 'web-terminal-tooling',
+              namespace: 'openshift-operators',
+            },
+          },
+        },
+        {
+          name: 'web-terminal-exec',
+          plugin: {
+            kubernetes: {
+              name: 'web-terminal-exec',
+              namespace: 'openshift-operators',
+            },
+          },
+        },
+      ],
+    },
+  },
+};
+export const createWorkspace = async (link: string, token: string) => {
+  const response = await fetch(`https://${link}/${WORKSPACE_ENDPOINT}`, {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${token}`,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify(workspace),
+  });
+  const data = await response.json();
+  return data.metadata.name;
+};
+
+export const getWorkspace = async (
+  link: string,
+  token: string,
+  name: string,
+) => {
+  const response = await fetch(
+    `https://${link}/${WORKSPACE_ENDPOINT}/${name}`,
+    {
+      method: 'GET',
+      headers: {
+        Authorization: `Bearer ${token}`,
+      },
+    },
+  );
+  const data = await response.json();
+  return [data.status.devworkspaceId, data.status.phase];
+};


### PR DESCRIPTION
This PR adds REST requests to initialize devworkspace and adds subprotocols which are then send to the proxy. These subprotocols contain basic information so that proxy knows for which pod to finish initialization and connect to it.
This PR should be discussed simultaneously with PR that introduces websocket proxy
Related to: https://github.com/janus-idp/webterminal-proxy/pull/1