### PR TITLE
feat: Operate First theme

### DIFF
--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -59,9 +59,11 @@
     "history": "^5.0.0",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
+    "react-helmet": "^6.1.0",
     "react-router": "6.3.0",
     "react-router-dom": "6.3.0",
-    "react-use": "^15.3.3"
+    "react-use": "^15.3.3",
+    "tabler-icons-react": "^1.56.0"
   },
   "devDependencies": {
     "@backstage/test-utils": "^1.2.2",
@@ -70,6 +72,7 @@
     "@testing-library/user-event": "^14.0.0",
     "@types/node": "^16.11.26",
     "@types/react-dom": "*",
+    "@types/react-helmet": "^6.1.6",
     "cross-env": "^7.0.0",
     "cypress": "^9.7.0",
     "eslint-plugin-cypress": "^2.10.3",

--- a/packages/app/src/App.tsx
+++ b/packages/app/src/App.tsx
@@ -32,6 +32,7 @@ import { badgesPlugin } from '@backstage/plugin-badges';
 import { grafanaPlugin } from '@k-phoen/backstage-plugin-grafana';
 import { OcmPage } from '@janus-idp/backstage-plugin-ocm';
 import { Logo } from './components/Logo/Logo';
+import { themes } from './themes';
 
 const app = createApp({
   apis,
@@ -44,6 +45,7 @@ const app = createApp({
       catalogIndex: catalogPlugin.routes.catalogIndex,
     });
   },
+  themes,
 });
 
 const AppProvider = app.getProvider();

--- a/packages/app/src/components/LinkTiles/LinkTile.tsx
+++ b/packages/app/src/components/LinkTiles/LinkTile.tsx
@@ -26,6 +26,7 @@ const useStyles = makeStyles((theme: BackstageTheme) =>
       '&:hover': {
         textDecoration: 'none',
       },
+      whiteSpace: 'nowrap',
     },
   }),
 );

--- a/packages/app/src/components/Root/Root.tsx
+++ b/packages/app/src/components/Root/Root.tsx
@@ -15,7 +15,7 @@
  */
 
 import React, { PropsWithChildren } from 'react';
-import { makeStyles } from '@material-ui/core';
+import { Grid, makeStyles } from '@material-ui/core';
 import HomeIcon from '@material-ui/icons/Home';
 import ExtensionIcon from '@material-ui/icons/Extension';
 import CategoryIcon from '@material-ui/icons/Category';
@@ -41,6 +41,12 @@ import {
 } from '@backstage/core-components';
 import MenuIcon from '@material-ui/icons/Menu';
 import SearchIcon from '@material-ui/icons/Search';
+import {
+  BrandGithub,
+  BrandSlack,
+  BrandTwitter,
+  BrandYoutube,
+} from 'tabler-icons-react';
 
 const useSidebarLogoStyles = makeStyles({
   root: {
@@ -77,6 +83,29 @@ const SidebarLogo = () => {
   );
 };
 
+const links = [
+  <a href="https://github.com/operate-first" target="_blank" rel="noreferrer">
+    <BrandGithub color="white" />
+  </a>,
+  <a
+    href="https://join.slack.com/t/operatefirst/shared_invite/zt-o2gn4wn8-O39g7sthTAuPCvaCNRnLww"
+    target="_blank"
+    rel="noreferrer"
+  >
+    <BrandSlack color="white" />
+  </a>,
+  <a
+    href="https://www.youtube.com/channel/UCe87bwqlGoBQs2RvMQZ5_sg"
+    target="_blank"
+    rel="noreferrer"
+  >
+    <BrandYoutube color="white" />
+  </a>,
+  <a href="https://twitter.com/OperateFirst" target="_blank" rel="noreferrer">
+    <BrandTwitter color="white" />
+  </a>,
+];
+
 export const Root = ({ children }: PropsWithChildren<{}>) => (
   <SidebarPage>
     <Sidebar>
@@ -94,8 +123,15 @@ export const Root = ({ children }: PropsWithChildren<{}>) => (
         <SidebarItem icon={LibraryBooks} to="docs" text="Docs" />
         <SidebarItem icon={ExtensionIcon} to="api-docs" text="APIs" />
         {/* <SidebarItem icon={CreateComponentIcon} to="create" text="Create..." /> */}
+        <SidebarSpace />
+        <Grid container spacing={2} justifyContent="center">
+          {links.map((l, idx) => (
+            <Grid item key={idx}>
+              {l}
+            </Grid>
+          ))}
+        </Grid>
       </SidebarGroup>
-      <SidebarSpace />
       <SidebarDivider />
       <SidebarGroup
         label="Settings"

--- a/packages/app/src/components/catalog/shared/InfoCard.tsx
+++ b/packages/app/src/components/catalog/shared/InfoCard.tsx
@@ -1,5 +1,10 @@
 import React from 'react';
-import { InfoCard as Card, Link, Table } from '@backstage/core-components';
+import {
+  InfoCard as Card,
+  Link,
+  Table,
+  WarningIcon,
+} from '@backstage/core-components';
 import { RELATION_OWNED_BY, RELATION_PART_OF } from '@backstage/catalog-model';
 import {
   EntityRefLinks,
@@ -8,6 +13,7 @@ import {
 } from '@backstage/plugin-catalog-react';
 import {
   Avatar,
+  Box,
   CardContent,
   CardHeader,
   Chip,
@@ -28,6 +34,17 @@ const useStyles = makeStyles(() => ({
     paddingBottom: 10,
   },
 }));
+
+export const Missing = ({ text }: { text: string }) => (
+  <Box sx={{ display: 'flex', alignItems: 'center' }}>
+    <span
+      style={{ marginTop: '-4px', marginBottom: '-4px', marginRight: '0.5em' }}
+    >
+      <WarningIcon fontSize="small" />
+    </span>
+    {text}
+  </Box>
+);
 
 export const InfoCard = () => {
   const classes = useStyles();
@@ -63,7 +80,7 @@ export const InfoCard = () => {
         ownedByRelations.length > 0 ? (
           <EntityRefLinks entityRefs={ownedByRelations} defaultKind="group" />
         ) : (
-          'No owner'
+          <Missing text="No owner" />
         ),
     },
     ...(isSystem || partOfDomainRelations.length > 0
@@ -77,7 +94,7 @@ export const InfoCard = () => {
                   defaultKind="domain"
                 />
               ) : (
-                'No domain'
+                <Missing text="No domain" />
               ),
           },
         ]
@@ -93,7 +110,7 @@ export const InfoCard = () => {
                   defaultKind="system"
                 />
               ) : (
-                'No system'
+                <Missing text="No system" />
               ),
           },
         ]
@@ -109,7 +126,7 @@ export const InfoCard = () => {
                   defaultKind="component"
                 />
               ) : (
-                'No parent'
+                <Missing text="No parent" />
               ),
           },
         ]

--- a/packages/app/src/components/home/HomePage.tsx
+++ b/packages/app/src/components/home/HomePage.tsx
@@ -1,4 +1,5 @@
 import React, { useState } from 'react';
+import { Helmet } from 'react-helmet';
 import { SearchContextProvider } from '@backstage/plugin-search-react';
 import {
   Content,
@@ -26,7 +27,7 @@ import {
 } from '@backstage/plugin-catalog-react';
 import useAsyncFn from 'react-use/lib/useAsyncFn';
 import useDebounce from 'react-use/lib/useDebounce';
-import { useApi } from '@backstage/core-plugin-api';
+import { useApi, configApiRef } from '@backstage/core-plugin-api';
 import { Entity } from '@backstage/catalog-model';
 import Logo from '../Logo/Logo';
 import { ICON_ANNOTATION, FEATURED_ANNOTATION } from '../../constants';
@@ -125,16 +126,19 @@ const CatalogCards = () => {
   };
 
   return (
-    <>
-      <FilterListIcon />{' '}
-      {allFilters.map(f => (
-        <Chip
-          label={f}
-          variant={activeFilters.includes(f) ? 'default' : 'outlined'}
-          onClick={handleFilterToggle(f)}
-        />
-      ))}
-      <Grid container justifyContent="center">
+    <Grid container justifyContent="center" alignContent="center" spacing={2}>
+      <Grid item>
+        <FilterListIcon />{' '}
+        {allFilters.map(f => (
+          <Chip
+            key={f}
+            label={f.slice(0, 1).toUpperCase() + f.slice(1)}
+            variant={activeFilters.includes(f) ? 'default' : 'outlined'}
+            onClick={handleFilterToggle(f)}
+          />
+        ))}
+      </Grid>
+      <Grid item xs={12} container justifyContent="center">
         {entities
           .filter(
             e =>
@@ -176,27 +180,38 @@ const CatalogCards = () => {
             </Grid>
           ))}
       </Grid>
-    </>
+    </Grid>
   );
 };
 export const HomePage = () => {
   const classes = useStyles();
+  const config = useApi(configApiRef);
   const { svg, container } = useLogoStyles();
 
   return (
     <SearchContextProvider>
       <Page themeId="home">
+        <Helmet>
+          <title>{config.getString('app.title')}</title>
+        </Helmet>
         <Content>
           <Grid container justifyContent="center" spacing={6}>
-            <HomePageCompanyLogo
-              className={container}
-              logo={<Logo classes={{ svg }} />}
-            />
-            <Grid container item xs={12} alignItems="center" direction="row">
-              <HomePageSearchBar
-                classes={{ root: classes.searchBar }}
-                placeholder="Search"
+            <Grid
+              container
+              item
+              justifyContent="center"
+              style={{ background: '#000' }}
+            >
+              <HomePageCompanyLogo
+                className={container}
+                logo={<Logo classes={{ svg }} />}
               />
+              <Grid container item xs={12} alignItems="center" direction="row">
+                <HomePageSearchBar
+                  classes={{ root: classes.searchBar }}
+                  placeholder="Search"
+                />
+              </Grid>
             </Grid>
             <Grid item xs={12}>
               <CatalogCards />

--- a/packages/app/src/themes.tsx
+++ b/packages/app/src/themes.tsx
@@ -1,0 +1,117 @@
+import {
+  BackstageTheme,
+  createTheme,
+  darkTheme,
+  genPageTheme,
+  lightTheme,
+  shapes,
+} from '@backstage/theme';
+
+import React from 'react';
+import DarkIcon from '@material-ui/icons/Brightness2';
+import LightIcon from '@material-ui/icons/WbSunny';
+import { ThemeProvider } from '@material-ui/core/styles';
+import CssBaseline from '@material-ui/core/CssBaseline';
+import { AppTheme } from '@backstage/core-plugin-api';
+
+const sharedColors = {
+  palette: {
+    error: {
+      main: '#8c4351',
+    },
+    warning: {
+      main: '#8f5e15',
+    },
+    info: {
+      main: '#34548a',
+    },
+    success: {
+      main: '#485e30',
+    },
+    banner: {
+      info: '#34548a',
+      error: '#8c4351',
+      text: '#343b58',
+      link: '#565a6e',
+    },
+    errorBackground: '#8c4351',
+    warningBackground: '#8f5e15',
+    infoBackground: '#343b58',
+    navigation: {
+      background: '#000',
+      indicator: '#ffcc00',
+      color: '#ccc',
+      selectedColor: '#fff',
+    },
+  },
+  defaultPageTheme: 'home',
+  /* below drives the header colors */
+  pageTheme: {
+    home: genPageTheme({ colors: ['#ffcc00', '#c19a00'], shape: shapes.wave }),
+    operator: genPageTheme({ colors: ['#000', '#333'], shape: shapes.round }),
+    documentation: genPageTheme({
+      colors: ['#8c4351', '#343b58'],
+      shape: shapes.wave2,
+    }),
+    service: genPageTheme({
+      colors: ['#8c4351', '#343b58'],
+      shape: shapes.wave,
+    }),
+    website: genPageTheme({
+      colors: ['#8c4351', '#343b58'],
+      shape: shapes.wave,
+    }),
+    library: genPageTheme({
+      colors: ['#8c4351', '#343b58'],
+      shape: shapes.wave,
+    }),
+    other: genPageTheme({ colors: ['#8c4351', '#343b58'], shape: shapes.wave }),
+    app: genPageTheme({ colors: ['#8c4351', '#343b58'], shape: shapes.wave }),
+    apis: genPageTheme({ colors: ['#8c4351', '#343b58'], shape: shapes.wave }),
+  },
+};
+
+const operateFirstTheme = createTheme({
+  ...sharedColors,
+  palette: {
+    ...lightTheme.palette,
+    ...sharedColors.palette,
+  },
+});
+
+const operateFirstDarkTheme = createTheme({
+  ...sharedColors,
+  palette: {
+    ...darkTheme.palette,
+    ...sharedColors.palette,
+    background: {
+      default: '#1e1e1e',
+    },
+  },
+});
+
+const providerFactory =
+  (theme: BackstageTheme) =>
+  ({ children }: React.PropsWithChildren<{}>) =>
+    (
+      <ThemeProvider theme={theme}>
+        <CssBaseline>{children}</CssBaseline>
+      </ThemeProvider>
+    );
+
+export const themes: AppTheme[] = [
+  {
+    id: 'light',
+    title: 'Light Theme',
+    variant: 'light',
+    icon: <LightIcon />,
+    Provider: providerFactory(operateFirstTheme),
+  },
+  {
+    id: 'dark',
+    title: 'Dark Theme',
+    variant: 'dark',
+    icon: <DarkIcon />,
+    Provider: providerFactory(operateFirstDarkTheme),
+  },
+];

--- a/yarn.lock
+++ b/yarn.lock
@@ -6201,6 +6201,13 @@
   dependencies:
     "@types/react" "^17"
 
+"@types/react-helmet@^6.1.6":
+  version "6.1.6"
+  resolved "https://registry.yarnpkg.com/@types/react-helmet/-/react-helmet-6.1.6.tgz#7d1afd8cbf099616894e8240e9ef70e3c6d7506d"
+  integrity sha512-ZKcoOdW/Tg+kiUbkFCBtvDw0k3nD4HJ/h/B9yWxN4uDO8OkRksWTO+EL+z/Qu3aHTeTll3Ro0Cc/8UhwBCMG5A==
+  dependencies:
+    "@types/react" "*"
+
 "@types/react-redux@^7.1.20":
   version "7.1.24"
   resolved "https://registry.yarnpkg.com/@types/react-redux/-/react-redux-7.1.24.tgz#6caaff1603aba17b27d20f8ad073e4c077e975c0"
@@ -6998,9 +7005,11 @@ anymatch@^3.0.3, anymatch@~3.1.2:
     history "^5.0.0"
     react "^17.0.2"
     react-dom "^17.0.2"
+    react-helmet "^6.1.0"
     react-router "6.3.0"
     react-router-dom "6.3.0"
     react-use "^15.3.3"
+    tabler-icons-react "^1.56.0"
 
 aproba@^1.0.3:
   version "1.2.0"
@@ -17531,7 +17540,7 @@ react-fast-compare@^3.1.1:
   resolved "https://registry.yarnpkg.com/react-fast-compare/-/react-fast-compare-3.2.0.tgz#641a9da81b6a6320f270e89724fb45a0b39e43bb"
   integrity sha512-rtGImPZ0YyLrscKI9xTpV8psd6I8VAtjKCzQDlzyDvqJA8XOW78TXYQwNRNd8g8JZnDu8q9Fu/1v4HPAVwVdHA==
 
-react-helmet@6.1.0:
+react-helmet@6.1.0, react-helmet@^6.1.0:
   version "6.1.0"
   resolved "https://registry.yarnpkg.com/react-helmet/-/react-helmet-6.1.0.tgz#a750d5165cb13cf213e44747502652e794468726"
   integrity sha512-4uMzEY9nlDlgxr61NL3XbKRy1hEkXmKNXhjbAIOVw5vcFrsdYbH2FEwcNyWvWinl103nXgzYNlns9ca+8kFiWw==
@@ -19561,6 +19570,11 @@ symbol-tree@^3.2.4:
   version "3.2.4"
   resolved "https://registry.yarnpkg.com/symbol-tree/-/symbol-tree-3.2.4.tgz#430637d248ba77e078883951fb9aa0eed7c63fa2"
   integrity sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==
+
+tabler-icons-react@^1.56.0:
+  version "1.56.0"
+  resolved "https://registry.yarnpkg.com/tabler-icons-react/-/tabler-icons-react-1.56.0.tgz#d2a6cf9160f25b370c38c356fa6284c254e5113e"
+  integrity sha512-FOme3w6PJIWDpeXqQ4xjArQqdxzrr9xNy7PSSgWpRzOUQ71RyZ7jt6WThsfyLBz5os78TPJRA8f/0NLjnKcx9A==
 
 taffydb@2.6.2:
   version "2.6.2"


### PR DESCRIPTION
Various visual fixes:

- Use Operate First colors as a theme (light and dark)
- Set `<title>` on Home page (previously only the title available from initial HTML load was used - this got overriden on any page within Backstage, so when user goes to Home->Catalog->Home, the title stays with whatever title was used on the Catalog page...
- Add warning icon to the "No owner" in the info card.
- Add the same social links we have on operate-first.cloud website
- Align Home page filters to center of the screen 