### PR TITLE
feat: Use cluster annotation instead of form field

### DIFF
--- a/plugins/web-terminal/package.json
+++ b/plugins/web-terminal/package.json
@@ -26,6 +26,7 @@
   "dependencies": {
     "@backstage/core-components": "^0.12.3",
     "@backstage/core-plugin-api": "^1.3.0",
+    "@backstage/plugin-catalog-react": "^1.2.4",
     "@backstage/theme": "^0.2.16",
     "@material-ui/core": "^4.9.13",
     "@material-ui/icons": "^4.9.1",


### PR DESCRIPTION
Uses new annotation in resource `kubernetes.io/api-server` instead of having to input a cluster API server manually
Related to: https://github.com/janus-idp/backstage-plugins/pull/94
Part of: https://github.com/janus-idp/backstage-plugins/issues/81