### PR TITLE
feat: Enable changing of namespace in UI

### DIFF
--- a/plugins/web-terminal/package.json
+++ b/plugins/web-terminal/package.json
@@ -24,6 +24,7 @@
   },
   "configSchema": "schema.d.ts",
   "dependencies": {
+    "@backstage/config": "^1.0.6",
     "@backstage/core-components": "^0.12.3",
     "@backstage/core-plugin-api": "^1.3.0",
     "@backstage/plugin-catalog-react": "^1.2.4",

--- a/plugins/web-terminal/schema.d.ts
+++ b/plugins/web-terminal/schema.d.ts
@@ -8,5 +8,10 @@ export interface Config {
      * @visibility frontend
      */
     webSocketUrl: string;
+    /**
+     * The namespace where DevWorkspace will be created
+     * @visibility frontend
+     */
+    defaultNamespace?: string;
   };
 }

--- a/plugins/web-terminal/src/components/NamespacePickerDialog/NamespacePickerDialog.tsx
+++ b/plugins/web-terminal/src/components/NamespacePickerDialog/NamespacePickerDialog.tsx
@@ -1,0 +1,118 @@
+import { Progress } from '@backstage/core-components';
+import {
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  DialogContentText,
+  FormControl,
+  Select,
+  MenuItem,
+  makeStyles,
+  Button,
+} from '@material-ui/core';
+import React, { useEffect } from 'react';
+
+const useStyles = makeStyles({
+  container: {
+    display: 'flex',
+    flexWrap: 'wrap',
+    justifyContent: 'center',
+    marginBottom: '10px',
+  },
+  buttonmargin: {
+    marginTop: '10px',
+    marginBottom: '10px',
+  },
+});
+
+type props = {
+  onInit: () => Promise<any>;
+  open: boolean;
+  previousNamespace: string;
+  handleClose: () => void;
+  onSubmit: (selectedNamesapce: string) => void;
+};
+
+export const NamespacePickerDialog = ({
+  onInit,
+  open,
+  previousNamespace,
+  handleClose,
+  onSubmit,
+}: props) => {
+  const classes = useStyles();
+  const namespaceRef = React.useRef<HTMLInputElement>(null);
+  const [selectedNamespace, setSelectedNamespace] = React.useState('');
+  const [namespaces, setNamespaces] = React.useState([]);
+  const [loading, setLoading] = React.useState(false);
+  const handleChange = (event: React.ChangeEvent<{ value: unknown }>) => {
+    setSelectedNamespace(event.target.value as string);
+  };
+
+  const handleSubmit = (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    onSubmit(selectedNamespace);
+  };
+
+  useEffect(() => {
+    setLoading(true);
+    onInit()
+      .then(setNamespaces)
+      .then(() => setLoading(false));
+  }, [onInit]);
+
+  return (
+    <Dialog open={open} onClose={handleClose}>
+      <DialogTitle>Choose a namespace</DialogTitle>
+
+      {loading && (
+        <DialogContent>
+          <DialogContentText>
+            Please wait while we fetch the list of namespaces
+          </DialogContentText>
+          <Progress />
+        </DialogContent>
+      )}
+
+      {!loading && (
+        <DialogContent>
+          <DialogContentText>
+            Unable to create devworkspace resource in {previousNamespace}{' '}
+            namespace, please choose a different one
+          </DialogContentText>
+          <form onSubmit={handleSubmit} className={classes.container}>
+            <FormControl>
+              <Select
+                name="namespace"
+                inputRef={namespaceRef}
+                onChange={handleChange}
+                value={selectedNamespace}
+                displayEmpty
+                required
+              >
+                <MenuItem value="" disabled>
+                  Select a namespace
+                </MenuItem>
+                {namespaces.map(namespace => {
+                  return (
+                    <MenuItem key={namespace} value={namespace}>
+                      {namespace}
+                    </MenuItem>
+                  );
+                })}
+              </Select>
+              <Button
+                type="submit"
+                color="primary"
+                variant="contained"
+                className={classes.buttonmargin}
+              >
+                Submit
+              </Button>
+            </FormControl>
+          </form>
+        </DialogContent>
+      )}
+    </Dialog>
+  );
+};

--- a/plugins/web-terminal/src/components/NamespacePickerDialog/index.tsx
+++ b/plugins/web-terminal/src/components/NamespacePickerDialog/index.tsx
@@ -1,0 +1,1 @@
+export { NamespacePickerDialog } from './NamespacePickerDialog';

--- a/plugins/web-terminal/src/components/TerminalComponent/utils/helpers.ts
+++ b/plugins/web-terminal/src/components/TerminalComponent/utils/helpers.ts
@@ -1,0 +1,7 @@
+import { Config } from '@backstage/config';
+
+const OPENSHIFT_TERMINAL_DEFAULT_NAMESPACE = 'openshift-terminal';
+
+export const getDefaultNamespace = (config: Config) =>
+  config.getOptionalString('webTerminal.defaultNamespace') ??
+  OPENSHIFT_TERMINAL_DEFAULT_NAMESPACE;

--- a/plugins/web-terminal/src/components/TerminalComponent/utils/index.ts
+++ b/plugins/web-terminal/src/components/TerminalComponent/utils/index.ts
@@ -1,1 +1,2 @@
-export { createWorkspace, getWorkspace } from './requests';
+export { createWorkspace, getWorkspace, getNamespaces } from './requests';
+export { getDefaultNamespace } from './helpers';

--- a/yarn.lock
+++ b/yarn.lock
@@ -7541,7 +7541,7 @@
   resolved "https://registry.yarnpkg.com/@types/range-parser/-/range-parser-1.2.4.tgz#cd667bcfdd025213aafb7ca5915a932590acdcdc"
   integrity sha512-EEhsLsD6UsDM1yFhAvy0Cjr6VwmpMWqFBCb9w07wVugF7w9nfajxLuVmngTIpgS6svCnm6Vaw+MZhoDCKnOfsw==
 
-"@types/react-dom@*", "@types/react-dom@<18.0.0", "@types/react-dom@^17":
+"@types/react-dom@*", "@types/react-dom@<18.0.0":
   version "17.0.18"
   resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-17.0.18.tgz#8f7af38f5d9b42f79162eea7492e5a1caff70dc2"
   integrity sha512-rLVtIfbwyur2iFKykP2w0pl/1unw26b5td16d5xMgp7/yjTHomkyxPYChFoCr/FtEX1lN9wY6lFj1qvKdS5kDw==


### PR DESCRIPTION
This PR adds a dropdown menu with all the namespaces in the cluster where user can choose proper namespace to start a pod in. This dropdown menu only displays if the request in default namespace (`openshift-terminal`). Chosen namespace is then used to initialize environment and is sent to the `webterminal-proxy`.
Example of form before first request:
![image](https://user-images.githubusercontent.com/47832967/218745600-2ed528c4-9ca3-437f-bbc1-142f07394b88.png)
When the request fails
![image](https://user-images.githubusercontent.com/47832967/218745691-1108ca9a-f944-4e00-95c3-ccb7e3fdb0d2.png)
*User must be able to read namespaces otherwise the list will be empty
Part of: https://github.com/operate-first/service-catalog/issues/213

**Edit** added functionality to input default namespace which will be used this configuration is optional and if not specified it uses `openshift-terminal` Example of usage:
```
webTerminal:
  webSocketUrl: "ws://localhost:8080/"
  defaultNamespace: "namespace"
```

**Edit 2** Updated version now displays a modal instead of inlining select
![image](https://user-images.githubusercontent.com/47832967/219643041-138f3074-8595-4d12-a918-e626976beab2.png)



Resolves https://github.com/operate-first/service-catalog/issues/213