### PR TITLE
feat: Add deployment and routes for webterminal-proxy

### DIFF
--- a/manifests/base/deployment.yaml
+++ b/manifests/base/deployment.yaml
@@ -54,6 +54,16 @@ spec:
             failureThreshold: 30
             periodSeconds: 10
             timeoutSeconds: 5
+        - name: webterminal
+          image: webterminal
+          command: ["./webterminal"]
+          ports:
+            - containerPort: 3000
+          resources:
+            limits:
+              cpu: 300m
+            requests:
+              cpu: 200m
       volumes:
         - name: ca-cert
           secret:

--- a/manifests/base/kustomization.yaml
+++ b/manifests/base/kustomization.yaml
@@ -5,6 +5,7 @@ resources:
   - deployment.yaml
   - service.yaml
   - route.yaml
+  - route-webterminal.yaml
   - postgres.yaml
   - serviceaccount.yaml
 commonLabels:
@@ -13,3 +14,5 @@ commonLabels:
 images:
   - name: service-catalog
     newName: quay.io/operate-first/service-catalog
+  - name: webterminal
+    newName: quay.io/operate-first/webterminal

--- a/manifests/base/route-webterminal.yaml
+++ b/manifests/base/route-webterminal.yaml
@@ -1,0 +1,10 @@
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  name: service-catalog-webterminal
+spec:
+  port:
+    targetPort: 3000
+  to:
+    kind: Service
+    name: service-catalog

--- a/manifests/base/service.yaml
+++ b/manifests/base/service.yaml
@@ -8,3 +8,5 @@ spec:
   ports:
     - port: 7007
       targetPort: 7007
+    - port: 3000
+      targetPort: 3000

--- a/manifests/overlays/prod/kustomization.yaml
+++ b/manifests/overlays/prod/kustomization.yaml
@@ -32,3 +32,4 @@ patches:
       name: service-catalog
 patchesStrategicMerge:
   - route.yaml
+  - route-webterminal.yaml

--- a/manifests/overlays/prod/route-webterminal.yaml
+++ b/manifests/overlays/prod/route-webterminal.yaml
@@ -1,9 +1,9 @@
 apiVersion: route.openshift.io/v1
 kind: Route
 metadata:
-  name: service-catalog
+  name: service-catalog-webterminal
   annotations:
     kubernetes.io/tls-acme: "true"
 spec:
   host: service-catalog.operate-first.cloud
-  path: "/"
+  path: "/webterminal"


### PR DESCRIPTION
This PR adds `webterminal` sidecar and routes that expose this sidecar on `service-catalog` service. 
This PR requires uploaded image on quay