### PR TITLE
fix: Fix originLocation.type check and prometheus.io/alert annotation

### DIFF
--- a/packages/backend/src/plugins/catalog.ts
+++ b/packages/backend/src/plugins/catalog.ts
@@ -32,7 +32,7 @@ class OpenshiftResourceProcessor implements CatalogProcessor {
       return resource;
     }
 
-    if (originLocation.type === 'rhacm-managed-cluster') {
+    if (originLocation.type === 'ocm-managed-cluster') {
       resource.metadata.annotations ||= {};
       const clusterId = resource.metadata.annotations[ANNOTATION_CLUSTER_ID];
       resource.metadata.annotations['prometheus.io/alerts'] = 'all';

--- a/packages/backend/src/plugins/catalog.ts
+++ b/packages/backend/src/plugins/catalog.ts
@@ -35,7 +35,7 @@ class OpenshiftResourceProcessor implements CatalogProcessor {
     if (originLocation.type === 'ocm-managed-cluster') {
       resource.metadata.annotations ||= {};
       const clusterId = resource.metadata.annotations[ANNOTATION_CLUSTER_ID];
-      resource.metadata.annotations['prometheus.io/alerts'] = 'all';
+      resource.metadata.annotations['prometheus.io/alert'] = 'all';
       resource.metadata.annotations[
         'prometheus.io/labels'
       ] = `managed_cluster_id=${clusterId}`;


### PR DESCRIPTION
This PR fixes issue with annotations not being properly added to entity in preprocessing.
Before fix:
![image](https://user-images.githubusercontent.com/47832967/220914009-574e3e82-24be-4711-843e-6b19ad37b8c6.png)
After fix:
![image](https://user-images.githubusercontent.com/47832967/220914069-e064dafd-2d45-40e3-8f16-8290a0abe3cc.png)

Also fixes in the second commit typo in `prometheus.io/alert` :no_mouth: 
