### PR TITLE
fix: Fix issues in webterminal deployment manifests

### DIFF
--- a/manifests/base/deployment.yaml
+++ b/manifests/base/deployment.yaml
@@ -56,9 +56,9 @@ spec:
             timeoutSeconds: 5
         - name: webterminal
           image: webterminal
-          command: ["./webterminal"]
+          command: ["./webterminal-proxy"]
           ports:
-            - containerPort: 3000
+            - containerPort: 8080
           resources:
             limits:
               cpu: 300m

--- a/manifests/base/route-webterminal.yaml
+++ b/manifests/base/route-webterminal.yaml
@@ -4,7 +4,7 @@ metadata:
   name: service-catalog-webterminal
 spec:
   port:
-    targetPort: 3000
+    targetPort: 8080
   to:
     kind: Service
     name: service-catalog

--- a/manifests/base/service.yaml
+++ b/manifests/base/service.yaml
@@ -8,5 +8,5 @@ spec:
   ports:
     - port: 7007
       targetPort: 7007
-    - port: 3000
-      targetPort: 3000
+    - port: 8080
+      targetPort: 8080


### PR DESCRIPTION
Fixes inconsitences between [webterminal-proxy port](https://github.com/janus-idp/webterminal-proxy/blob/main/proxy.go#L215) (which is set to 8080) and ports in manifests. It also fixes a typo in deployment where part of the name of the binary was missing