### PR TITLE
fix: Service ports missing name

### DIFF
--- a/manifests/base/service.yaml
+++ b/manifests/base/service.yaml
@@ -6,7 +6,9 @@ spec:
   selector:
     app.kubernetes.io/component: app
   ports:
-    - port: 7007
+    - name: service-catalog
+      port: 7007
       targetPort: 7007
-    - port: 8080
+    - name: webterminal
+      port: 8080
       targetPort: 8080


### PR DESCRIPTION
When there are two and more ports specified in the Service they require name. This PR adds name for these ports (More info can be found [here](https://access.redhat.com/solutions/6106961)