### PR TITLE
feat: Add SRE portal to service catalog

### DIFF
--- a/app-config.prod.yaml
+++ b/app-config.prod.yaml
@@ -104,6 +104,9 @@ kubernetes:
           dashboardUrl: https://console-openshift-console.apps.jerry.ionos.emea.operate-first.cloud
           dashboardApp: openshift
 
+webTerminal:
+  webSocketUrl: "wss://service-catalog.operate-first.cloud/webterminal"
+
 ocm:
   cluster: 'infra'
 

--- a/packages/app/src/components/catalog/resource.tsx
+++ b/packages/app/src/components/catalog/resource.tsx
@@ -16,6 +16,8 @@ import {
   ClusterStatusCard,
 } from '@janus-idp/backstage-plugin-ocm';
 import LinkTiles from '../LinkTiles/LinkTiles';
+import { RunBooksCard } from './shared/RunBooksCard';
+import { WebTerminal } from '@internal/backstage-plugin-web-terminal';
 
 const resource = (
   <LayoutWrapper>
@@ -66,6 +68,16 @@ const resource = (
 
     <EntityLayout.Route if={isTechDocsAvailable} path="/docs" title="Docs">
       <EntityTechdocsContent />
+    </EntityLayout.Route>
+    <EntityLayout.Route path="/sre" title="SRE">
+      <Grid container spacing={3}>
+        <Grid item xs={12}>
+          <RunBooksCard />
+        </Grid>
+        <Grid item xs={12}>
+          <WebTerminal />
+        </Grid>
+      </Grid>
     </EntityLayout.Route>
   </LayoutWrapper>
 );


### PR DESCRIPTION
This PR adds SRE portal page to resource entity. 
SRE portal features:
- [x] Alerts  from the cluster 
- [x] Runbooks card which displays runbooks which are connected to the alert
- [x] Webterminal through which developers can access the cluster
Example of running page:
![image](https://user-images.githubusercontent.com/47832967/226609522-5ca06672-d5ed-4e4d-9895-70b44d2f7789.png)
  