### PR TITLE
feat: Use REST proxy instead of direct cluster requests

### DIFF
--- a/app-config.local.yaml
+++ b/app-config.local.yaml
@@ -49,6 +49,7 @@ kubernetes:
 
 webTerminal:
   webSocketUrl: "wss://example.com:3000"
+  restServerUrl: "https://example.com/rest:3000"
 
 ocm:
   cluster: 'dev-cluster'

--- a/app-config.prod.yaml
+++ b/app-config.prod.yaml
@@ -106,6 +106,7 @@ kubernetes:
 
 webTerminal:
   webSocketUrl: "wss://service-catalog.operate-first.cloud/webterminal"
+  restServerUrl: "https://service-catalog.operate-first.cloud/webterminal/rest"
 
 ocm:
   cluster: 'infra'

--- a/plugins/web-terminal/schema.d.ts
+++ b/plugins/web-terminal/schema.d.ts
@@ -13,5 +13,12 @@ export interface Config {
      * @visibility frontend
      */
     defaultNamespace?: string;
+
+    /**
+     * The URL of the restServer
+     *
+     * @visibility frontend
+     */
+    restServerUrl: string;
   };
 }

--- a/plugins/web-terminal/src/components/TerminalComponent/utils/requests.ts
+++ b/plugins/web-terminal/src/components/TerminalComponent/utils/requests.ts
@@ -1,6 +1,7 @@
 const WORKSPACE_ENDPOINT = `apis/workspace.devfile.io/v1alpha2/namespaces`;
 
 export const createWorkspace = async (
+  restServerUrl: string,
   link: string,
   token: string,
   namespace: string,
@@ -48,7 +49,7 @@ export const createWorkspace = async (
   };
 
   const response = await fetch(
-    `https://${link}/${WORKSPACE_ENDPOINT}/${namespace}/devworkspaces`,
+    `${restServerUrl}?url=https://${link}/${WORKSPACE_ENDPOINT}/${namespace}/devworkspaces`,
     {
       method: 'POST',
       headers: {
@@ -66,13 +67,14 @@ export const createWorkspace = async (
 };
 
 export const getWorkspace = async (
+  restServerUrl: string,
   link: string,
   token: string,
   name: string,
   namespace: string,
 ) => {
   const response = await fetch(
-    `https://${link}/${WORKSPACE_ENDPOINT}/${namespace}/devworkspaces/${name}`,
+    `${restServerUrl}?url=https://${link}/${WORKSPACE_ENDPOINT}/${namespace}/devworkspaces/${name}`,
     {
       method: 'GET',
       headers: {
@@ -84,13 +86,20 @@ export const getWorkspace = async (
   return [data.status.devworkspaceId, data.status.phase];
 };
 
-export const getNamespaces = async (link: string, token: string) => {
-  const response = await fetch(`https://${link}/api/v1/namespaces`, {
-    method: 'GET',
-    headers: {
-      Authorization: `Bearer ${token}`,
+export const getNamespaces = async (
+  restServerUrl: string,
+  link: string,
+  token: string,
+) => {
+  const response = await fetch(
+    `${restServerUrl}?url=https://${link}/api/v1/namespaces`,
+    {
+      method: 'GET',
+      headers: {
+        Authorization: `Bearer ${token}`,
+      },
     },
-  });
+  );
   const data = await response.json();
   if (response.status !== 200) {
     return [];


### PR DESCRIPTION
This PR updates frontend to use webterminal-proxy for REST requests instead of direct requests against cluster. This done to avoid issue when response from the cluster does not include `Access-Control-Allow-Origin` and therefore output of the request cannot be parsed. 